### PR TITLE
Chaos Daemons - Scions of the Warp Update

### DIFF
--- a/Chaos.Daemons.40K.-.Codex.cat
+++ b/Chaos.Daemons.40K.-.Codex.cat
@@ -1,0 +1,10056 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="83d27dcf-7aba-2f77-c5c0-6dbf86c8e185" revision="46" gameSystemId="e1ebd931-a209-3ce4-87b4-d9918d25530b" gameSystemRevision="0" battleScribeVersion="1.15" name="Chaos Daemons: Codex (2013)" books="Scions of the Warp" authorName="BSData team (Original Authors: LM, JJ)" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entries>
+    <entry id="d85d-423c-4d50-6754" name="[FW] Chaos Knight Errant" points="370.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="f8b8-c2f6-da27-ef34" name="Heavy Stubber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="43ea-8c61-6ece-7fd8" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Stubber" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="6"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 3"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="ccb8-f74f-1dd0-6077" name="Foe-reaper Chainsword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="1584-8b40-c412-d0f2" name="Foe-reaper" hidden="false">
+              <description>Add +1 to the Str D table result when rolling against enemy Monstrous and Gargantuan Creatures.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="8c5b-a403-e254-ca5b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Foe-reaper Chainsword" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Foe Reaper"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="82da-1864-9ed2-428c" name="Ion Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="70d3-a431-ac30-0257" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Ion Shield" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the start of the opponents shooting phase, select the facing of the Ion Shield. The Ion Shield confers a 4+ Invunerable save against that facing until the start of your opponents next shooting phase."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="c601-6e0f-1b5d-d11f" name="Dirge Caster" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="401d-544c-f37b-d1ae" name="Dirge Caster" hidden="false">
+              <description>An enemy model within 6&quot; of a vehicle with this special rule cannot fire Overwatch.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links/>
+        </entry>
+        <entry id="22cf-36ca-2099-f5e6" name="Thermal Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="1eff-2ad6-b994-8892" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Thermal Cannon" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast (5&quot;), Melta"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="4f34-21d0-1281-4951" name="Daemon Knight upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="146e-d990-9e0f-06ee" name="Khorne" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="561e-4d2e-f55f-4c10" name="Daemon Knight of Khorne" hidden="false">
+                  <description>Confers Daemon (aligned with Khorne) and Hatred (Slaanesh). May re-roll the dice to determine the number of Stomp attacks and gains +D3 attacks on the charge instead of +1.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="a086-508c-cea9-1d82" name="Tzeentch" points="65.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="df0e-4875-155b-d39d" name="Daemon Knight of Tzeentch" hidden="false">
+                  <description>Confers Daemon (aligned with Tzeentch) and Hatred (Nurgle). May re-roll failed to hit rolls of 1 and Heavy stubber guns gain Soul-Blaze.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="dfb0-5793-8b5f-e9a2" name="Nurgle" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="0c99-da9f-ba14-cbd2" name="Daemon Knight of Nurgle" hidden="false">
+                  <description>Confers Daemon (Aligned with Nurgle) and Hatred (Tzeentch). Gains It Will Not Die!</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="ddcb-c383-3e86-b561" name="Slaanesh" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="e937-6feb-55ee-c21d" name="Daemon Knight of Slaanesh" hidden="false">
+                  <description>Gains Daemon (aligned with Slaanesh) and Hatred (Khorne). All models in base contact with the knight at the start of the fight sub-phase must pass a Leadership check at -2 or be reduced to I1 for the rest of the fight.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="1f5d-612e-37a4-76c9" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Chaos Knight Errant" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="12"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="6"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="8497-c3c9-40ac-b817" name="[FW] Chaos Knight Paladin" points="425.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="20c0-6f73-bca0-ee9a" name="Heavy Stubbers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="f91f-61d9-9b44-0260" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Stubber" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="6"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 3"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="9357-f25d-8529-e91d" name="Foe-reaper Chainsword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="fbbb-57ac-db27-d22d" name="Foe-reaper" hidden="false">
+              <description>Add +1 to the Str D table result when rolling against enemy Monstrous and Gargantuan Creatures.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="72de-5d1c-5e5f-1036" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Foe-reaper Chainsword" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Foe Reaper"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="d236-d2c8-9afa-2ba6" name="Ion Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="7b8e-ad6e-edf0-5cee" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Ion Shield" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the start of the opponents shooting phase, select the facing of the Ion Shield. The Ion Shield confers a 4+ Invunerable save against that facing until the start of your opponents next shooting phase."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="6c59-3637-2bd4-92cc" name="Dirge Caster" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="6228-2b9e-8685-9de4" name="Dirge Caster" hidden="false">
+              <description>An enemy model within 6&quot; of a vehicle with this special rule cannot fire Overwatch.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links/>
+        </entry>
+        <entry id="0f0d-ccb8-17f7-e7b8" name="Rapid-Fire Battle Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="ae6a-b4d8-181e-0d97" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Rapid-Fire Battle Cannon" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="72&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 2, Large Blast (5&quot;)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="4e67-3246-62a1-f4e0" name="Daemon Knight upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b20e-4df2-285f-ea59" name="Khorne" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="835b-3459-5cb7-5125" name="Daemon Knight of Khorne" hidden="false">
+                  <description>Confers Daemon (aligned with Khorne) and Hatred (Slaanesh). May re-roll the dice to determine the number of Stomp attacks and gains +D3 attacks on the charge instead of +1.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="750f-94f7-1ee1-4c6a" name="Tzeentch" points="65.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="55ef-275b-a5be-13a7" name="Daemon Knight of Tzeentch" hidden="false">
+                  <description>Confers Daemon (aligned with Tzeentch) and Hatred (Nurgle). May re-roll failed to hit rolls of 1 and Heavy stubber guns gain Soul-Blaze.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="d6c9-7c0d-f768-9fb0" name="Nurgle" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="f3d5-2f51-dfe5-83ef" name="Daemon Knight of Nurgle" hidden="false">
+                  <description>Confers Daemon (Aligned with Nurgle) and Hatred (Tzeentch). Gains It Will Not Die!</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="da87-9694-106f-3b22" name="Slaanesh" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="1ce0-06ee-2e7d-bb96" name="Daemon Knight of Slaanesh" hidden="false">
+                  <description>Gains Daemon (aligned with Slaanesh) and Hatred (Khorne). All models in base contact with the knight at the start of the fight sub-phase must pass a Leadership check at -2 or be reduced to I1 for the rest of the fight.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="9cc1-038e-5bd6-1903" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Chaos Knight Paladin" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="12"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="6"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="498ce75c-5d46-e1d2-0f14-137a9bb181f9" name="[FW] Mamon, Daemon Prince of Nurgle" points="220.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="f2b73df5-623b-065a-0102-142947f062ee" name="Contagion Spray" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="2802a936-25b3-8e37-1886-8a670c92ea78" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Contagion Spray" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="1"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Poisoned (2+)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="0f925f56-b880-2167-a227-3975386bd705" name="Posioned (2+)" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="5c33d640-d49f-7706-5f1c-6877a902f152" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Mamon, Daemon Prince of Nurgle" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value=""/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="7"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value=""/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="10011336-0645-f357-b9e3-62cc9353777b" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="59dc6a3b-2b28-c19e-37a6-749fe8017412" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4b502c9e-21e1-3e24-ba02-0ee8b871b54b" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="30ef41ca-de9c-b196-431d-e68da97bd355" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="206cc00a-c1d8-d0f5-573b-29c35a751686" targetId="bc27e394-d6c3-024b-4eab-144dd9379571" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3d25-233a-29ab-408c" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="455837f9-83d8-2331-718c-2bf9aafca66c" name="[FW] Uraka &apos;The Warfiend&apos;" points="200.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="d88daf30-bd22-ee7a-9d53-ce6805efccd9" name="The Executioner&apos;s Axe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="e8ea3b6f-7aef-e7f8-cadf-8505511079c2" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Executioner&apos;s Axe" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Two Handed, Fleshbane, Decapitating Blow (ID on to wound of 6)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="9b794b80-4016-154e-3d41-643c44307591" name="Daemonic Gifts" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="29974d83-3563-2143-5d10-662539a8d980" targetId="925fc93b-51ed-95bb-4d26-e27055d1857f" linkType="profile">
+              <modifiers/>
+            </link>
+            <link id="dbbaf31b-12c2-c356-71f0-32fd4920dfab" targetId="274da1cc-d0f3-8e8c-4ded-3d27931a934e" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="05546575-8cda-0b8e-8a6d-88dd49fc62e9" name="Daemonic Rewards" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="18a603a7-6f5c-8418-d8dd-c62c6c82536f" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Unholy Frenzy" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The Daemon has the Rage and Rampage special rules."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="720733f0-c8b6-8e8b-acba-680b839b6a9a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Uraka &apos;The Warfiend&apos; (FW)" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="4058f9f5-6798-dc67-3283-5723df46e037" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b1ad856c-798f-0bb8-c702-79f605d6a5a9" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a8aebe6b-b4da-09ba-0c48-6a45f44b4e7f" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="07ed-91ec-3c8c-8480" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="03a50d85-e35b-58a5-2b75-a6897063e232" name="Aetaos&apos;rau&apos;keres" points="999.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="599baf7d-9b50-ce02-060f-863d7bf799fe" name="The Staff of Cataclysm" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="890643c8-08a7-d6ba-59bc-1d50cb283121" name="The Staff of Cataclysm" hidden="false">
+              <description>Aetaos must remain stationary to use and cannot use when in an assault. Aetaos must pass a Ld check for each usage of the staff. If passed, the barrage goes as planned. If failed, the opponent gets to target the attack.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="088da6ed-9753-cf4c-fdde-32eb7d6c929a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Staff of Cataclysm" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Infinite"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="-"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Apocalyptic Barrage (6+D3),  Haywire, Posion 4+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="171fe76a-572b-a3d5-ad23-ea30c9862f9c" name="Icon of Chaos" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="a5d4bce7-d2ce-1102-d038-9970f0464eb4" name="Chosen of Tzeentch" hidden="false">
+          <description>Must generate a total of four powers, two from the Discipline of Change (ignoring the maximum limit). Others may be from the other disciplines in the BRB.</description>
+          <modifiers/>
+        </rule>
+        <rule id="e52ac45b-87d3-6c9b-982a-dd78c8bcf7e3" name="Render of the Veils" hidden="false">
+          <description>Shooting attack with 48&quot; and LoS of Aetaos, using 5&quot; Large Blast marker. Place D6+3 Pink horrors where the attack lands. They deploy using Deep Strike rules, but may not shoot. 
+
+If there is no space for the pink horrors, or no models, they are then destroyed. The pink horrors do not count towards point cost and are worth no victory points.</description>
+          <modifiers/>
+        </rule>
+        <rule id="cb88805a-37a9-09e9-5102-841c86002ebd" name="Mantle of Twisted Fates" hidden="false">
+          <description>Any successful deny the witch can then be bounced onto the original caster at 4+ on a D6. These attacks hit automatically and in occasions where both must take a test, Aetaos counts as being the user.</description>
+          <modifiers/>
+        </rule>
+        <rule id="900f7bc3-67ce-2da9-72d2-e4aaa606ec92" name="Dark Jealousy" hidden="false">
+          <description>If another Greater Daemon, Daemon Prince or Daemon Lord is within 18&quot; at the beginning of the controlling players shooting phase, Aetaos must direct all of his ranged attacks at them instead (Regardless of if they&apos;re friend or foe).</description>
+          <modifiers/>
+        </rule>
+        <rule id="2dd928fb-ebba-ed2a-d55a-b3fdd687a592" name="Pysker: ML 4" hidden="false">
+          <description>Mastery Level 4, power generation as listed in Chosen of Tzeentch.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="adb5c6e7-25ad-02c1-2798-f604dd847324" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Aetaos&apos;rau&apos;keres - Demon Lord of Tzeentch" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Gargantuan Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="8"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="8"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="9"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-/3++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="d0e4a257-e496-da38-15ff-adda36909ffe" targetId="4f9feb72-fede-03da-69d8-6efe86756bc3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="92f36400-204c-6464-ac42-61083ccfd00e" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ff7a05d5-3381-13f9-bf5b-5a0d8244a05a" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4da6b06c-4f5f-bb0a-fb36-8ee0f0b278fe" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0753fde3-8dfb-11a6-c449-39a9b91d3d93" name="An&apos;ggrath the Unbound" points="888.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="007c2aaa-2fc5-bd0d-0cb5-365b0a2bc2ff" name="Axe of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="b5e58351-9ff9-50e4-1eb6-3a8c5731be4b" targetId="596ac2cf-087d-e484-c8f1-506793046ef5" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="5b6af34b-89a3-a910-6c7d-3a622d8a5979" name="Icon of Chaos" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="8a43c1c3-7026-3783-e4b9-4bc2ccf80151" name="Blood Frenzy" hidden="false">
+          <description>An&apos;ggrath must charge if an enemy is in range at the start of the assault phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="7a7824ff-2d52-3d5e-1802-c328255e1be3" name="The Deathbringer" hidden="false">
+          <description>Counts as being equipped with assault grenades when charging. Receives an additional +D6 attacks on the charge. Passes Deny the Witch on a 2+</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="e6b0e0f0-8fdb-44c8-dff2-a296f7adb317" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="An&apos;ggrath the Unbound - Demon Lord of Khorne" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Gargantuan Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="8"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="8"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="7"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="2+/3++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="c2dec3fb-89d9-16cb-7d27-ff94f8f8d23a" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Daemonic Armour" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Confers a 2+ armour save"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="fcc84e4d-2018-7511-5802-f1035f381b51" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Bloodlash of Khorne" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&apos;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 2"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="28aadfe3-2c45-9bb5-2259-5ff6d1138831" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="64ffe53e-6f16-f5c9-7b02-2b04222a4a3a" targetId="4f9feb72-fede-03da-69d8-6efe86756bc3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="926746bf-b680-91fa-f717-850760f1b7b6" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8b24187e-2af3-4960-eb00-f2667c1cd6c5" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="489317a0-3776-4cc9-c45c-20d0a6417b22" name="Daemon Prince (Heavy)" points="145.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="150b-4008-eb38-9905" name="Must Choose One:" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a558-afd2-4e67-a24d" targetId="96fb-4c60-2a63-3e5d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="2794-2375-4f82-cd96" targetId="e272-3cf0-8c8b-70de" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="b1fc-c49b-c8af-ef3f" targetId="5bf8-d122-c25f-e889" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="068d-34fc-3bce-1424" targetId="1489-43b7-64bb-2164" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="3e18cd2f-635b-af47-20f4-d48a369313a9" name="Primary Detachment" points="0.0" categoryId="7fc5b655-812e-45ed-98ff-db8847d356da" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+  </entries>
+  <rules/>
+  <links>
+    <link id="96d2-92df-bd5e-912c" targetId="e5a9-3830-8d2a-7cfc" linkType="entry" categoryId="ff36a6f3-19bf-4f48-8956-adacfd28fe74">
+      <modifiers/>
+    </link>
+    <link id="e96e-db72-cd1e-23e3" targetId="c764-6b3b-f49f-c61e" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="4038-e15a-4b22-1843" targetId="158e-6391-7216-0921" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="8cb7-dde6-f565-0f6c" targetId="2fc2-d3c6-a640-8672" linkType="entry" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
+      <modifiers/>
+    </link>
+    <link id="2fea-4024-4f96-117c" targetId="003f-11f8-f5df-a9c7" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="c16e-320b-e286-059e" targetId="5f84-effb-3544-c55f" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="a387-df65-c063-8b9a" targetId="f4be-0336-9c09-01b0" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="0803-1286-c383-ec09" targetId="e95e-1ccc-d38c-be0a" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="6514-6bf7-873a-1c6c" targetId="8eb9-f254-6303-3d3c" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="936e-6d86-2ccb-1b42" targetId="d8b0-0434-ac1e-6868" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="4ac0-632a-80e4-f66e" targetId="4f40-5660-e8fd-2fc2" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="563a-5b09-f694-784f" targetId="d28f-a8b9-6af1-ae20" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="75da-ae51-6478-8006" targetId="9ef1-ea94-798e-830c" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="f3ea-7c9f-b1f9-ff87" targetId="11ed-c0dd-7520-27e0" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="bea6-b66e-ef91-7ad5" targetId="aebb-848c-24c3-ccd8" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="2746-62b7-61dd-2716" targetId="e81c-01b0-044a-bbde" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="d615-02ae-0ed1-770c" targetId="e0f6-c210-b534-0200" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="fd5c-a8c2-c51b-a030" targetId="55ea-fb07-07c4-7a4d" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="6a52-bf46-d17b-29a6" targetId="a9cf-4334-0021-b8c1" linkType="entry" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
+      <modifiers/>
+    </link>
+    <link id="6c47-2be0-97d6-2241" targetId="5c3a-0f55-df92-83e0" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="3011-421d-80a1-b1bf" targetId="f457-2e18-4b93-4bcb" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="d3f5-2add-e0c2-202e" targetId="77e0-abe4-f8f5-e6d3" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="cd60-32a3-614d-6b49" targetId="741d-4dac-a6fb-a523" linkType="entry" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
+      <modifiers/>
+    </link>
+    <link id="6bd1-3a60-56c5-95f3" targetId="69ff-0427-3a47-5b25" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="e732-347e-fc58-6430" targetId="044f-5642-ff01-477a" linkType="entry" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
+      <modifiers/>
+    </link>
+    <link id="78a9-42bf-5992-dae8" targetId="b443-1a05-e312-2414" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="89f8-ab26-305f-479b" targetId="21a5-9eb3-eda1-39da" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="be3b-e0ff-cf65-9f63" targetId="2572-b8b0-35d7-814a" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="2931-09e6-0d4c-eeb6" targetId="9ef1-ea94-798e-830c" linkType="entry" categoryId="bf93-7277-bf48-16f7">
+      <modifiers/>
+    </link>
+    <link id="fbdc-87ed-7574-0c61" targetId="f457-2e18-4b93-4bcb" linkType="entry" categoryId="bf93-7277-bf48-16f7">
+      <modifiers/>
+    </link>
+    <link id="dab6-4d44-781e-ad34" targetId="21a5-9eb3-eda1-39da" linkType="entry" categoryId="bf93-7277-bf48-16f7">
+      <modifiers/>
+    </link>
+    <link id="0320-bbe1-b4c9-d13a" targetId="d28f-a8b9-6af1-ae20" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="7417-cdce-5613-f565" targetId="2572-b8b0-35d7-814a" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="2056-417a-d16e-dce9" targetId="77e0-abe4-f8f5-e6d3" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="cd17-3c68-14bf-1b42" targetId="3e57-8b86-1e1f-e2fd" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="5fbe-d355-7249-094b" targetId="ef6c-d947-4eaf-1387" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="846f-0ade-cd97-79ad" targetId="4238-f87d-1eec-8d86" linkType="entry" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a">
+      <modifiers/>
+    </link>
+    <link id="00f6-3ffc-d9af-0d15" targetId="1b3b-5b77-f87a-3fc2" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="64c7-e41b-d44a-a822" targetId="a608-a4d2-4e8b-0dc9" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="54c4-d96a-2685-77f1" targetId="2ba5-dc49-9624-6220" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="a1ca-1130-d39a-cd1e" targetId="e0b0-ac29-3689-5cd0" linkType="entry" categoryId="bf93-7277-bf48-16f7">
+      <modifiers/>
+    </link>
+    <link id="0fc3-1294-0196-e702" targetId="e0b0-ac29-3689-5cd0" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="cda1-68c9-a6fd-6860" targetId="4007-b0dd-6642-d429" linkType="entry" categoryId="28b94f51-e66b-4096-aa59-0c9df620a77d">
+      <modifiers/>
+    </link>
+    <link id="e2c0-f981-72c3-73be" targetId="4007-b0dd-6642-d429" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="a9e3-d5f0-1f80-56db" targetId="3bc2-20f7-a09f-3be4" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="dfd8-dc75-e653-194f" targetId="ea18-5586-602d-a2be" linkType="entry" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188">
+      <modifiers/>
+    </link>
+    <link id="bf2e-c64e-a92a-f09b" targetId="dcd6-0ba0-61b2-d060" linkType="entry" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188">
+      <modifiers/>
+    </link>
+    <link id="ebc7-041f-a75e-86ab" targetId="c695-e2b9-0e86-cc18" linkType="entry" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188">
+      <modifiers/>
+    </link>
+    <link id="4e77-c520-4e2a-7fee" targetId="a217-f06a-68b8-34b8" linkType="entry" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188">
+      <modifiers/>
+    </link>
+    <link id="8ac9-3634-9066-3c36" targetId="6f7a-93c2-621e-ca80" linkType="entry" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188">
+      <modifiers/>
+    </link>
+    <link id="5795-6660-b297-a685" targetId="dac2-d0ef-2a14-4bb4" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="5749-a0d7-e352-7e28" targetId="bb4d-dbfa-7136-7bdb" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="d221-997d-99e7-c51f" targetId="cf2e-c247-0a75-6303" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="632e-1594-7e55-3d15" targetId="34c6-7ff9-4b28-db17" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="19ea-14e4-c806-5859" targetId="7578-1a86-dfce-72f4" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="92ee-e4a8-2a34-967b" targetId="ea39-f9f1-aa7c-a710" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="d212-4b89-ed94-30be" targetId="fbcb-3de0-566f-2bbe" linkType="entry" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2">
+      <modifiers/>
+    </link>
+    <link id="846a-ae27-b521-0915" targetId="8128-60c8-7afc-e9db" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="4364-0360-c913-91c4" targetId="8fb1-3c5c-7566-1010" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="2cf8-3a7a-b0bb-242e" targetId="2505-61ad-84ef-417b" linkType="entry" categoryId="c888f08a-6cea-4a01-8126-d374a9231554">
+      <modifiers/>
+    </link>
+    <link id="99a9-0388-2568-adcc" targetId="34da-cb86-e965-3aec" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="3f44-9a4d-5850-8586" targetId="a025-4bcd-12e9-b8be" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+    <link id="e479-cdde-5ceb-58ea" targetId="3f80-0d32-7480-5131" linkType="entry" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438">
+      <modifiers/>
+    </link>
+    <link id="0083-199d-45df-ffe4" targetId="0899-4ef9-27d7-b992" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="9aa2-a3e7-0281-e7b7" targetId="9cda-7277-c184-6ce6" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="73ab-6d60-f6f5-c265" targetId="e58a-0ce2-a4e5-5ff0" linkType="entry" categoryId="ef2b-83bd-1bad-5742">
+      <modifiers/>
+    </link>
+    <link id="bbad-a440-f384-965d" targetId="3943-d478-17aa-78b5" linkType="entry" categoryId="9050-d437-3301-7e42">
+      <modifiers/>
+    </link>
+    <link id="aed9-6003-452a-00ff" targetId="eed3-8190-0a7c-54d4" linkType="entry" categoryId="9050-d437-3301-7e42">
+      <modifiers/>
+    </link>
+    <link id="d6c0-7c24-7544-31c5" targetId="1844-1826-3675-2a90" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="2c4a-140f-6483-d28f" targetId="2932-5432-0a06-3738" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="ecd4-d78d-669b-128e" targetId="bac2-c4f5-3a15-4166" linkType="entry" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7">
+      <modifiers/>
+    </link>
+    <link id="a893-cc46-de93-381e" targetId="7eeb-4507-a35b-c789" linkType="entry" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6">
+      <modifiers/>
+    </link>
+  </links>
+  <sharedEntries>
+    <entry id="e0f6-c210-b534-0200" name="[FW] Blight Drones of Nurgle" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armout 13">
+      <entries>
+        <entry id="f6b0-9b49-d0ac-fa2e" name="Blight Drones" points="150.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="f40b-94c9-5060-828e" name="Mawcannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="2d7b-6f13-5d9e-94a2" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Mawcannon (Phlegm)" hidden="false" book="">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Large Blast (5&quot;)"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="4139-0ae0-b912-a409" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Mawcannon (Vomit)" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="725c-a84d-34af-df9f" name="Reaper Autocannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="fdea-029d-e60c-448d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Reaper Autocannon" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 2, Twin-linked"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="e0fa-9afe-69d0-6965" name="Explosion of Pus" hidden="false">
+              <description>When a Blight drone loses its last HP, it always explodes instead of wrecks.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="208e-1a6d-591f-7e44" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Blight Drones of Nurgle" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="2"/>
+                <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="12"/>
+                <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+                <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Flyer, Hover)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="da76-bb10-68e4-a973" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="8653-1bd0-56ac-8fef" targetId="87adee1e-acae-74dc-0663-046470e4c144" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="a745-e842-b1c9-bb0b" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="55ea-fb07-07c4-7a4d" name="[FW] Blood Slaughterers of Khorne" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="IA Apoc (2013)" page="0">
+      <entries>
+        <entry id="1775-6463-f336-7ecf" name="Blood Slaughterer of Khorne" points="130.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="888c-a9fd-44d5-205a" name="Weapons" defaultEntryId="9299-7c9c-7e95-56c7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries>
+                <entry id="9299-7c9c-7e95-56c7" name="2x Dreadnought CCW" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules/>
+                  <profiles/>
+                  <links>
+                    <link id="5e1a-d080-4c60-234c" targetId="8cfe-19e9-8e41-ce7c" linkType="profile">
+                      <modifiers/>
+                    </link>
+                  </links>
+                </entry>
+                <entry id="462a-5376-49ed-faba" name="Impaler and Dreadnought CCW" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+                  <entries/>
+                  <entryGroups/>
+                  <modifiers/>
+                  <rules>
+                    <rule id="a9ae-d988-afb4-ca2a" name="Impaler" hidden="false" page="0">
+                      <description>Drags the target model into Close Combat. Counts as a shooting attack that hits on a 4+. If successfuly hit or penetrating (and the target survives), move the target 2D6&quot; straight towards the Blood Slaughterer.
+Cannot drag model through obstructions it cannot normally pass through and stops 1&quot; away from the obstruction.
+
+Super-heavies, Gargantuan Creatures and buildings cannot be dragged by the impaler.</description>
+                      <modifiers/>
+                    </rule>
+                  </rules>
+                  <profiles>
+                    <profile id="b132-f490-6648-6baa" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Impaler" hidden="false" page="0">
+                      <characteristics>
+                        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+                        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Impaler"/>
+                      </characteristics>
+                      <modifiers/>
+                    </profile>
+                  </profiles>
+                  <links/>
+                </entry>
+              </entries>
+              <entryGroups/>
+              <modifiers/>
+              <links/>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <rules>
+            <rule id="9ba2-a46d-4032-ab0d" name="Fury of Khorne" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+            <rule id="af36-0f90-af35-f5af" name="Rampage" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+            <rule id="2150-e341-f5ad-e251" name="Blind Fury" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="7538-b181-3e83-8945" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Blood Slaughterer of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="1"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+                <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+                <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+                <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker)"/>
+              </characteristics>
+              <modifiers>
+                <modifier type="decrement" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="1775-6463-f336-7ecf" childId="462a-5376-49ed-faba" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </profile>
+          </profiles>
+          <links>
+            <link id="5ca5-d0e9-2ecb-49c5" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="6e45-8ba2-8e45-070b" targetId="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="ca7e-080f-5e91-77c1" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="8e33-a09a-d2ab-45c0" targetId="87adee1e-acae-74dc-0663-046470e4c144" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="fbcb-3de0-566f-2bbe" name="[FW] Chaos Decimator Daemon Engine" points="205.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="IA Apoc (2013)" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="429f-8581-b0b3-7684" name="Dedications of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="6ee2-13f7-2821-7841" name="Dedications of Khorne" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="44db-13fc-44b9-9bf9" name="Rampage" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="96f5-39e0-9c71-7077" name="Dedications of Nurgle" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="a5f6-934c-3cfa-8847" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3b7f-e739-5b75-a0f8" name="Dedications of Slaanesh" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="8f49-f316-6449-ec77" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Defensive Grenades" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="0160-e3d2-f9b4-b934" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Assault Grenades" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="2f81-d253-f97c-b1f9" name="Dedications of Tzeentch" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="7827-4be6-1aae-3770" name="Dedications of Tzeentch" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="d0b0-ca8b-0d30-c5c3" name="Weapons" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="84a9-a3f5-9c28-1042" name="Butcher Cannon" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="2f2a-25dd-07a1-f72d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Butcher Cannon" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 4"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="44ad-c0af-676a-c503" name="Storm Laser" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="87f1-dd37-ad1b-9ab7" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Storm Laser" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy D3+2"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="6fc3-6a8b-47b5-91f4" name="Soulburner Petard" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="c1ea-6da7-e6c9-eb61" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Soulburner Petard" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 1, Large Blast (5&quot;), Rending"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="e998-300a-efb7-fa14" name="Heavy Conversion Beam" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="0955-d470-d392-5625" name="Firing Calibration" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles>
+                <profile id="b25c-8cbc-29bf-fbd3" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Conversion Beam 0-18" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Up to 18&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast (5&quot;), Firing Calibration"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="0133-d0bc-b919-346e" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Conversion Beam 18-42" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="18&quot;-42&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast (5&quot;), Firing Calibration"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="a206-6675-08e6-a72c" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Heavy Conversion Beam 42-72" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="42&quot;-72&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="10"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast (5&quot;), Firing Calibration"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="b28d-d8e9-ab08-7b9d" name="Decimator Siege Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="638d-e56f-d38b-a2da" name="Smash" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles>
+                <profile id="add2-28c7-853e-d10b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Decimator Siege Claw" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Shred, Smash"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+                <profile id="f562-d723-49c0-6b9e" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="in-built Heavy Flamer" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="8cc9-1f1d-dc8d-bdd4" name="Unholy Vigor" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="5b82-5f7a-8060-0c03" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Chaos Decimator Daemon Engine" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="8"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker)"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="fbcb-3de0-566f-2bbe" incrementChildId="b28d-d8e9-ab08-7b9d" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="55b0-dafe-aec7-d4da" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fd53-8a69-698f-442b" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="54d0-e599-d3f1-828e" targetId="87adee1e-acae-74dc-0663-046470e4c144" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="c764-6b3b-f49f-c61e" name="[FW] Cor&apos;bax Utterblight" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="33d9-fe98-d097-8fa6" name="Gaping Maw" hidden="false">
+          <description>Cor’bax’s vast maw opens wide enough to swallow enemies whole. When fighting against infantry models, any To Hit rolls of 5 or 6 made in the Assault phase by Cor’bax have the Instant Death special rule. Roll to wound and save with these attacks separately.</description>
+          <modifiers/>
+        </rule>
+        <rule id="bd33-ff5a-7b00-bf43" name="Noisome Tide of Flesh" hidden="false">
+          <description>Cor’bax Utterblight’s corporeal form is little more than a mass of roiling gelatinous and pestilential flesh, which makes him even harder to harm than many of his Daemon kin and allows him to seethe across the battlefield like a destroying tide of plague.
+
+Cor’bax Utterblight inflicts D3 Hammer of Wrath hits when charging. He ignores all dangerous terrain and difficult terrain. He counts as being armed with assault grenades when charging. In addition, if he is destroyed replace his model with the Massive Blast (7&quot;) template. All models under the template that do not have the Daemon of Nurgle special rule suffer a single Poisoned (4+) AP 4 hit.</description>
+          <modifiers/>
+        </rule>
+        <rule id="e300-9af4-712b-b5c2" name="Poisoned (3+)" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="2d0b-97c5-c3e9-1a72" name="Psyker (Mastery Level 2)" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="5be2-af17-a4c1-0472" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Cor&apos;bax Utterblight" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creatures (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="8"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="7"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="9229-a1d7-f975-c159" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="96c6-be67-4b84-0774" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0573-74f9-ab7a-a512" targetId="ece8645d-de4f-c7a6-1031-2ea5d25d807f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cd05-3399-c82b-4fd6" targetId="ded5-cb2d-42be-cabf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a025-4bcd-12e9-b8be" name="[FW] Giant Chaos Spawn" points="80.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour 13" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="283b-f879-7749-f7ba" name="Rage" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="d0ef-2780-7128-8b50" name="Random Attacks" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="8a40-d222-3d28-ec02" name="Mutated Beyond Sanity" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="6602-6a5a-83b5-0044" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Giant Chaos Spawn" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="D6+2"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="ab83-929d-246b-85c2" targetId="179e20b2-b985-74fe-b514-8f6da2e8dea3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f5b3-1740-8ec5-e7d4" targetId="ded5-cb2d-42be-cabf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="7578-1a86-dfce-72f4" name="[FW] Greater Brass Scorpion of Khorne" points="700.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+      <entries>
+        <entry id="e726-7476-fb56-7d53" name="Scorpion Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="eb4b-3cdd-7a96-8ddc" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Scorpion Cannon" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 10"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="3153-6879-c891-1255" name="Soulburner Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="7f6d-17cc-9ec1-e697" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Soulburner Cannon" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="10"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Primary Weapon 1, Large Blast, Ignores Cover"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="0999-d80a-fe5e-609d" name="Hellmaw Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="34c8-0b9f-2358-c6f3" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Hellmaw Cannon" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="27a6-788f-244c-a815" name="Daemon" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="e044-3650-00d5-1f08" name="Frenzied Charge" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+          <modifiers/>
+        </rule>
+        <rule id="b4ba-09f1-b258-5425" name="Runes of the Blood God" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+          <modifiers/>
+        </rule>
+        <rule id="fd2e-d9f4-5564-b61d" name="Doomsday Reactor" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+          <modifiers/>
+        </rule>
+        <rule id="bbda-e21d-0134-4fdd" name="Multi-legged Terror" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="03cc-0625-51c7-e972" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Greater Brass Scorpion of Khorne" hidden="false" book="Imperial Armour: Apocalypse (2013)" page="51">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="14"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="9"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Super-heavy Walker"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7d93-57d9-ddf7-0593" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="e95e-1ccc-d38c-be0a" name="[FW] Kytan Daemon Engine" points="525.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="8df3-2800-053d-704d" name="Great Cleaver of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="a941-b4d0-b517-d3fd" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Great Cleaver of Khorne" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="230c-06c9-fdd7-146c" name="Kytan Gatling Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="47b0-09e7-6347-ac37" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Kytan Gatling Cannon" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 8, Pinning"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="9548-f2f8-76f6-27d2" name="Unstoppable Slaughter" hidden="false">
+          <description>The Kytan may assault another unit if the unit it was shooting at was killed in the previous phase.</description>
+          <modifiers/>
+        </rule>
+        <rule id="0f97-1326-9770-606f" name="Crusader" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="0641-eb10-280b-8ba8" name="Daemonforge" hidden="false">
+          <description>Once per game, at the start of any shooting or assault phase, the model may activate its Daemonforge. 
+
+Until the end of that phase, the model in question may re-roll all its failed to-wound/armour penetration rolls.
+At the end of the phase in which this is used, roll a D6. On a 1 the model immediately loses a Hull Point with no save allowed.</description>
+          <modifiers/>
+        </rule>
+        <rule id="a402-53a6-2513-90b6" name="Rage" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="aaf3-8b67-b448-f27e" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Kytan Daemon Engine of Khorne" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value=""/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="6"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Super-Heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="d1fd-9991-3d85-53c1" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6e23-b4f0-11da-c8fd" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9833-d510-b287-47fb" targetId="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="e81c-01b0-044a-bbde" name="[FW] Plague Hulk of Nurgle" points="150.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="7b14-7bb0-09b5-150f" name="Rancid Vomit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="dbc1-3bdd-86aa-cdf5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Rancid Vomit" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Poisoned (3+)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="5960-dff0-b36d-cab3" name="Rot Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="cee6-b725-5cfd-3b4c" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Rot Cannon" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 1, Rending, Large Blast (5&quot;)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="eb07-e2ae-d592-494b" name="Melee Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="76d3-8bdf-2124-9d0a" name="Iron Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="769f-f3a6-47b9-3727" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Iron Claw" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Meele, Unwieldy, Specialist Weapon, Melee"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="8a65-17e8-4280-8748" name="Warpsword" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="1204-e5a0-ffce-dc12" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Warpsword" hidden="false">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-Crafted, Specialist Weapon"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="a55b-fd34-288a-b25c" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Plague Hulk of Nurgle" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="2"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="2088-3fe8-f256-2200" targetId="87adee1e-acae-74dc-0663-046470e4c144" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d4c0-d9e6-6ddc-1da6" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="589c-719f-59a8-0f27" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2505-61ad-84ef-417b" name="[FW] Samus" points="375.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="cac9-d392-5143-d463" name="Slaughtering Blade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="5ff7-2914-f280-94cc" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Slaughtering Blade" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Armourbane, Murderous Strike"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="71cc-1408-e927-eb53" name="Hatred (Infantry)" hidden="false">
+          <modifiers/>
+        </rule>
+        <rule id="f31e-cb12-790e-09f4" name="Born of Murder" hidden="false">
+          <description>Samus must enter play via deep strike (and must start in reserve). If a model with the character type is slain before Samus enters play, place a counter within 3&quot; of the model. If the player wishes to, on the turn Samus enters play he may Deep strike at one of these counters. If he does so, he deep strikes without scattering (provided he can deep strike without hitting either friendly orwithin 1&quot; of enemy models).</description>
+          <modifiers/>
+        </rule>
+        <rule id="49ff-91fb-4017-36e2" name="Whispers of Madness" hidden="false">
+          <description>1.If Samus is part of your army, all enemy reserve rolls are -1 regardless. If the opponent has ongoing reserves, a unit may fail to arrive on a D6 roll of a 1.
+
+2. If Samus is part of your army, then the Warp Charge cost of any blessing psychic powers are increased by +1.
+
+3. Any model in combat with, or taking a fear test to charge at Samus will have their Ld halved unless they are fearless or stubborn.</description>
+          <modifiers/>
+        </rule>
+        <rule id="c298-9e5a-e4e7-109d" name="Adamantium Will" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="a9de-146d-0f76-3f27" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Samus, Daemon Prince of the Ruinstorm" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="7"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="5f69-9a74-2365-afb1" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f469-c9f7-865e-d475" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1316-e1a0-f363-b55e" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2dc8-1d72-d9ec-78fa" targetId="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8bfc-779e-014a-98c4" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fe25-168f-0ce6-4681" targetId="ded5-cb2d-42be-cabf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="fdf3-7ddc-dd10-03fa" name="[FW] Spined Chaos Beast" points="140.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Imperial Armour 13" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="36cd-3d95-9d2b-3549" name="Daemon of Chaos" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="bd7a-6e2d-7462-1205" name="Daemon of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="0440-5152-c30c-7960" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="56b1-014d-ecfc-e4a6" name="Daemon of Nurgle" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="fd6d-b375-ec9e-6a41" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3af0-6fbb-099f-69ee" name="Daemon of Slaanesh" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="2c53-b2fb-63c0-b8bc" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="fcc0-0bb5-f991-4296" name="Daemon of Tzeentch" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="06b8-e049-dd1a-efa7" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="be69-f13c-5760-9918" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Spined Chaos Beast" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="1"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="5"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="ce28-5b63-d3b5-e7ba" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ba08-dcf3-cc9d-024e" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5fce-d99f-b66d-0978" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="70df-998b-910a-460c" targetId="ded5-cb2d-42be-cabf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="210c-b684-6cd6-7bc3" name="A&apos;rgath, The King of Blades" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="25">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="8ef9-d7c0-9c00-f428" name="Blade King" hidden="false">
+          <description>When fighting in a challenge, the bearer always hits on a 2+.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="0e44-4fa2-0c9c-360f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="A&apos;rgath, The King of Blades" hidden="false" book="Scions of the Warp" page="25">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Blade King, Specialist Weapon"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0813-3363-5fc6-fbbc" targetId="e002-c436-5f54-4f00" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8609-0eaa-6027-8e0c" name="Armour of Scorn" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="1bd9-8840-7b05-2d50" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Armour of Scorn" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="3+ Armour Save, Adamantium Will. Reduce the S of any attack that targets the bearer by 1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="117c-1330-2d04-0721" targetId="d7f7-7923-faeb-8dc5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0bf1d6b4-3c08-3649-d746-2e1982938ba3" name="Aura of Acquiescense" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="e5864ca1-3f08-27e7-c947-a6b5e6894043" name="Aura of Acquiescense" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="d74306ce-6dee-47c1-b111-56a519e9e910" name="Aura of Decay" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="d643aa6f-f9bd-fa12-9a49-4fe9e707e74a" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Aura of Decay" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Ranged Weapon, but Daemon may be locked in combat and still use it, as may the targets.  When used all enemy models within 6&quot; and in Line of Sight of the Daemon automaticlally a Strength 2 AP - hit, roll to wound as normal."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="5922820d-710f-7d1e-d1fc-a26d7fa92b9a" name="Banner of Blood" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="316594ca-e57d-7444-2b2e-621c9e910a84" targetId="8375119f-55e4-7cf7-70ef-36ae7da87f7e" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8fb1-3c5c-7566-1010" name="Be&apos;lakor, The Dark Master" points="350.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Dataslate: Be&apos;lakor" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="ab66-ed9c-c212-d55d" name="Eternal Warrior" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="7dfe-6f8b-0021-4c92" name="Psyker (Mastery Level 3)" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="ff98-4ead-e7f3-0724" name="Shadow Form" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="122c-b33c-4eb0-bace" name="Lord of Torment" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="d4f5-ac98-cf55-a964" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Be&apos;lakor, The Dark Master" hidden="false" book="Dataslate: Be&apos;lakor" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="8"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-/4++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="48c7-b9f5-c224-0bab" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Blade of Torment" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Melee"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Armourbane, Fleshbane, Master-Crafted, Specialist Weapon"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="9f45-6bb8-b904-804e" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="258c-7eb1-357b-7ad1" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="d7f7-edac-f3aa-aa8c" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d10b-4344-1959-352a" targetId="ded5-cb2d-42be-cabf" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="b443-1a05-e312-2414" name="Beast of Nurgle" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="f341-0a10-d29c-ba9f" name="Beasts" points="52.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="fdf4-334e-174e-97e8" targetId="f756a086-e42b-7741-83e2-2ea37e828462" linkType="profile">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="e0eb-3884-25e1-3ba8" name="Attention Seeker" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="d4eb-85bf-071c-5d54" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="418b-fdd0-6773-ed91" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c1f4-9316-75ff-6cef" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4629-13e9-0219-d339" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ba53-1ca5-2d48-075a" targetId="6ac2f44f-d25b-8ea5-d36a-5f2267ad7613" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6911-6750-27f4-c5c3" targetId="ece8645d-de4f-c7a6-1031-2ea5d25d807f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5a2a-a21c-c85f-8bdd" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="54b7ec6d-44c0-56e7-ab13-aef0be6e9b83" name="Blasted Standard" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="7c37d54b-a1f8-dbeb-6472-ff93706f9477" targetId="1b5f95f3-b556-15b4-3752-1cbfdcdb1be7" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1e268eeb-78d5-99ca-50e9-4737b7b50c95" name="Blessings of the Blood God" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="fa47817f-b950-f467-c758-e22bd670f09e" name="2+ Invul Save Against Force/Psychic Attacks" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="158e-6391-7216-0921" name="Bloodcrushers of Khorne" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="95fb-a926-71d8-c0c0" name="Bloodcrushers" points="45.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="4b44-42cb-91cb-60b6" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodcrusher of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Cavalry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="c404-1122-61d9-82cf" name="Upgrade one Bloodcrusher to Bloodhunter" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="0eb8-7af4-c5fd-f24d" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodhunter of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Cavalry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="4117-df78-eca2-38b9" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="08ad-375e-7803-6d50" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="0e30-cf04-08e6-fae2" targetId="5922820d-710f-7d1e-d1fc-a26d7fa92b9a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="2dc5-ba5f-9a50-c1d3" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="3a40-1eeb-d3f7-806a" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="da32-ec4c-4cc3-c196" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="40b7-d997-900c-d3a4" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="ef0e-d83c-b832-1159" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5f1d-bbcc-076c-28e6" targetId="2f692f01-8637-a8c7-de2c-23060a63958b" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2fc2-d3c6-a640-8672" name="Bloodletters of Khorne" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="e8bb-5f23-06e4-2681" name="Upgrade one Bloodletter to Bloodreaper" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="f046-45a9-7a3d-eca6" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodreaper of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="86df-fdb4-7d8a-61c2" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="0388-83e6-f4f8-71f6" name="Bloodletters" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="10" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="36e4-61b9-a365-189f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodletters of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="1ad3-c75a-47b0-2ba4" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="a405-b80b-4a95-d159" targetId="5922820d-710f-7d1e-d1fc-a26d7fa92b9a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="a49b-08f2-0da5-2213" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="d2ce-add7-abdc-4740" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4214-4c88-f72a-95cd" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4b0e-9314-cce1-6158" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4f48-7577-6172-f66e" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="11f2-922b-54cb-d5cd" targetId="2f692f01-8637-a8c7-de2c-23060a63958b" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="5f84-effb-3544-c55f" name="Bloodthirster of Insensate Rage" points="275.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="1d3d-069f-ba14-b23e" name="Hellforged Artefacts of Khorne" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="5f84-effb-3544-c55f" childId="fec0-6945-5503-ed8f" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links>
+            <link id="c8dd-8138-5cd1-871d" targetId="65e3-2ded-3ff6-cd8d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="f791-3f56-b17a-3cb0" targetId="8609-0eaa-6027-8e0c" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="8d13-c724-aba4-9d13" name="Weapon" defaultEntryId="5d72-49b2-546d-cf0a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="fec0-6945-5503-ed8f" name="Hellforged Artefacts" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="5f84-effb-3544-c55f" childId="1d3d-069f-ba14-b23e" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <links>
+                <link id="a4a8-94c6-c218-bcb4" targetId="69c6-5dab-8b48-383e" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="e733-21c3-9550-636b" targetId="5c8a-f784-1e04-6a67" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <links>
+            <link id="5d72-49b2-546d-cf0a" targetId="f714-0bc5-7ea7-6716" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="174c-8160-8851-3daa" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodthirster of Insensate Rage" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Monsterous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="10"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="e152-fffc-5096-1ea4" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9b22-df8d-eb3b-7314" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d336-4514-bffe-8564" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="ad8e-4fc5-6ed2-4d2a" targetId="274da1cc-d0f3-8e8c-4ded-3d27931a934e" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="92ca-d8a1-946d-3f70" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1f6f-8089-5ca5-b396" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="c590-9413-9e7b-76d8" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="cb69-3104-ff03-d85b" targetId="41b0-7f97-46cb-d026" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f4be-0336-9c09-01b0" name="Bloodthirster of Unfettered Fury" points="250.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="25bd-3c27-651a-5edc" name="Hellforged Artefacts of Khorne" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="f4be-0336-9c09-01b0" childId="914d-5475-c62f-651e" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links>
+            <link id="c543-b6c1-0515-f924" targetId="65e3-2ded-3ff6-cd8d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7752-3c4f-2fbe-9b09" targetId="8609-0eaa-6027-8e0c" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="bbbe-32ca-12e6-1d0d" name="Weapon" defaultEntryId="dc25-de0d-f5c5-900f" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="dc25-de0d-f5c5-900f" name="Axe of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="613c-a04a-29ca-e2d1" targetId="596ac2cf-087d-e484-c8f1-506793046ef5" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="914d-5475-c62f-651e" name="Hellforged Artefacts" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="f4be-0336-9c09-01b0" childId="25bd-3c27-651a-5edc" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <links>
+                <link id="29a6-bafa-96fd-38d4" targetId="69c6-5dab-8b48-383e" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="ffd7-c84e-7ce8-d328" targetId="5c8a-f784-1e04-6a67" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="5945-94a6-469c-6975" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodthirster of Unfettered Fury" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Monsterous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="10"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="a7db-48c4-ccf5-7cb0" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c7a8-e79d-7b67-64ae" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5b83-52c6-e039-5cb8" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="c8fd-710d-ace1-76b5" targetId="274da1cc-d0f3-8e8c-4ded-3d27931a934e" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="c768-b62a-1d6f-a58a" targetId="b4b482b2-93bd-ba5a-dca6-212fb94c2445" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="37d6-77e9-46e3-3e26" targetId="0026fb8e-53f6-ba79-ccfe-d4f67bbf7b9c" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8120-63e8-6755-dad9" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="ab95-604a-aca8-3e51" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="f3c7-18c2-6d88-5b6d" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="c9bc31d8-5209-01af-e962-cb637c6c9640" name="Blue Horror Crew" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="602850f2-51dc-3e8f-d880-288841581882" name="Blue Horror Crrew" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="7eeb-4507-a35b-c789" name="Burning Chariot of Tzeentch" points="100.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="f3ae-98bc-846c-73ba" name="Exalted Flamer" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="5a4a-9d57-7412-13b2" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Exalted Flamer" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="f170-10e7-ee5a-f49c" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Blue Fire of Tzeentch" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="18&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy D3, Warpflame"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="2cd4-4617-5b52-60b4" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Pink Fire of Tzeentch" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Torrent, Warpflame"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="f304-c2a9-94be-8fc5" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="1b32-d44e-6ac3-ae91" targetId="de070752-2c93-5c2c-d937-5cab4ff68531" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="dffc-0c71-fad4-bf6a" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxPoints" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="7561-4db9-b8f1-a9c3" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Burning Chariot of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="10"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="10"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Fast, Open-Topped, Skimmer"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7949-e44f-8c8e-5496" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6e47-3a89-90c4-aa01" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="2caf-4706-e988-a044" targetId="add2bfb1-23e3-51d0-287b-1e4a6d4f4f19" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b204-d9f0-6cdc-2c7f" targetId="c9bc31d8-5209-01af-e962-cb637c6c9640" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="77e0-abe4-f8f5-e6d3" name="Burning Skyhost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="3fb6-28a0-8123-2166" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="053c-9b7b-ce8b-e242" targetId="eeb8-23a2-fd50-af88" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="4689-e34c-e85b-86d4" targetId="1844-1826-3675-2a90" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="ef46-c13a-a784-b57b" name="Units" minSelections="9" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1885-a825-aef3-1e29" targetId="a608-a4d2-4e8b-0dc9" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="0d52-647b-0546-5b67" targetId="7eeb-4507-a35b-c789" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="be4d-c13a-4ead-3feb" name="Trail of Transmuting Flame" hidden="false">
+          <description>If a Burning Chariot of Tzeentch from a Burning Skyhost moves Flat Out, pick an unengaged enemy unit it moved over. That unit suffers D6 S5 AP4 hits with Soul Blaze and Warpflame special rules. Use the final position of the Burning Chariot for the purposes of determining Wound allocation; vehicles are always hit on their side armour.
+
+Furthermore, Screamers from a Burning Skyhost cause D3+1 S4 AP- hits when making a Slashing Attack rather than D3 hits. These attacks also have the Soul Blaze and Warpflame special rules.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="0774-1e55-d340-24c8" targetId="2a61-6373-1e4b-0211" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5219-bc81-d437-ab89" targetId="de070752-2c93-5c2c-d937-5cab4ff68531" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1885-27f8-ff32-7d5f" targetId="d938-b9d2-3b0b-df13" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="34c6-7ff9-4b28-db17" name="Chaos Furies" points="5.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="ff7a-3ecc-03d0-fd15" name="Furies" points="6.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="798f-e71d-67b9-2891" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Furies of Chaos" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="2"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="34a9-9b96-f69a-bc3a" name="Daemonic Alignment" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="67c0-4042-3117-d074" name="Daemon of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="34c6-7ff9-4b28-db17" incrementChildId="ff7a-3ecc-03d0-fd15" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="cb8c-59e5-d464-09c1" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="0fe7-a35b-c366-52a0" name="Daemon of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="34c6-7ff9-4b28-db17" incrementChildId="ff7a-3ecc-03d0-fd15" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="eb27-68fb-b0af-6c8f" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f469-a2df-e26a-5034" name="Daemon of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="34c6-7ff9-4b28-db17" incrementChildId="ff7a-3ecc-03d0-fd15" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="a337-8b45-0fb1-1de2" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="3138-2940-1528-34ec" name="Daemon of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="34c6-7ff9-4b28-db17" incrementChildId="ff7a-3ecc-03d0-fd15" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1436-cd08-c335-2a66" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="cd32-f1a2-8e8a-743f" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ac53-2b46-0bf3-f4aa" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="583f-bc35-a65d-e3ce" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f9d5b4d9-3d52-5281-61f4-01d7db2b7efb" name="Cloud of Flies" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="fbd751e5-b6c1-3044-818b-28713cbbbe54" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Cloud of Flies" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Models with this gift do not suffer the penalties for charging enemies through cover, but instead fight at their normal Initiative in the ensuing combat. In addition enemy units do not gain their bonus Attacks for charging a unit including one or more models with this gift."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="dcd6-0ba0-61b2-d060" name="Cohort of Blood" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="dd81-1698-0c62-11a4" name="Bloodletters" defaultEntryId="bf17-bf0d-f106-019d" minSelections="8" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="bf17-bf0d-f106-019d" targetId="2fc2-d3c6-a640-8672" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="100a-4b59-4709-1e27" name="Skulltaker" defaultEntryId="596f-a8c9-6c70-8f71" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="596f-a8c9-6c70-8f71" targetId="2f67-49b4-2d18-024c" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="728f-8717-e17d-ce99" name="Heralds of Khorne" defaultEntryId="3b95-a789-809c-e9b4" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="3b95-a789-809c-e9b4" targetId="eff5-c688-5678-5765" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="aadd-5751-8edb-6bac" name="Decapitating Strike" hidden="false">
+          <description>Any to-wound roll of a 6 against non-vehicle models have Instant Death.</description>
+          <modifiers/>
+        </rule>
+        <rule id="8694-10f6-e655-85d5" name="Veterans of the Great Arenas" hidden="false">
+          <description>All units have +1 Strength and Fleet</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="9b31-146b-abbc-344c" name="Corruption" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="d3e3-f417-0dc5-37d4" name="Hyper-Infection" hidden="false" book="">
+          <description>Hits by this weapon automatically Wound, no need to roll. Use the bearer&apos;s S for Armour Pen and Instant Death.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="b4d9-4b9b-4dbb-3fd5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Corruption" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="*"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Touch of Rust, Hyper-Infection"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="bebc-94df-39aa-4958" targetId="dd3b7105-d7b0-42cc-a648-94930c817ae7" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="e58a-0ce2-a4e5-5ff0" name="Daemon Flock" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="aea8-ff29-4355-1d51" name="Chaos Furies" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4ee4-e5a1-1b0c-c8b3" targetId="34c6-7ff9-4b28-db17" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="eed3-8190-0a7c-54d4" name="Daemon Lord" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="c885-b8b0-8fba-670b" name="Daemon Lord" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="5db2-2bd4-de6d-be67" targetId="5f84-effb-3544-c55f" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="a51b-4915-26c2-8d05" targetId="f4be-0336-9c09-01b0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="e692-d656-9cbb-f314" targetId="4f40-5660-e8fd-2fc2" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7f8a-8958-1b03-5baf" targetId="bac2-c4f5-3a15-4166" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="036d-bdbf-a7f4-4b57" targetId="34da-cb86-e965-3aec" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="c1bd-1e25-99ee-091b" targetId="2932-5432-0a06-3738" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="d6da-f348-9d05-d9df" targetId="dac2-d0ef-2a14-4bb4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="f3ee-e452-af94-7fa3" targetId="bb4d-dbfa-7136-7bdb" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="72e3-f883-b532-adf5" targetId="cf2e-c247-0a75-6303" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="87ad-f738-5076-869b" targetId="8fb1-3c5c-7566-1010" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="718b-5acb-4a65-a5fc" targetId="3bc2-20f7-a09f-3be4" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="f18931f3-81ef-799f-eaa3-07c0067183b9" name="Daemon of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="49dcd576-26a2-acfc-d007-2b662962b9a6" name="Hatred (Daemon of Slaanesh)" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="04de-aae9-5df0-f33d" targetId="9a4fd561-d31a-c6a3-01d6-44c544f51df7" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cf75-d91c-949f-d16e" targetId="179e20b2-b985-74fe-b514-8f6da2e8dea3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d302-c80e-ff1a-0f01" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="bc47ebb1-051d-12f5-85f9-a2520a661c51" name="Daemon of Nurgle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="83f92eae-db3e-69da-3a67-f976a19c0831" name="Hatred (Daemon of Tzeencth)" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="9fd5-0a81-886a-e143" targetId="4aee02f6-2a24-9888-98d5-a94b7b7f371b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5e2b-f1eb-91dd-bbe5" targetId="05846d0f-c133-80db-c36e-8af301cf4bec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d89f-055b-4e8c-70cb" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="08fa-6964-147f-c5db" targetId="179e20b2-b985-74fe-b514-8f6da2e8dea3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" name="Daemon of Slaanesh" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="806a8b12-d9da-f6a3-43af-c51c7e88ac56" name="Hatred (Daemon of Khorne)" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="559dd6d7-a406-0212-8275-7b49a5208b90" name="Additional inches when Run, Flat Out moves" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="80be-06c5-2673-7f6f" targetId="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b714-4166-c794-598a" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4b37-ef03-6b35-23fc" targetId="179e20b2-b985-74fe-b514-8f6da2e8dea3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f9b1-14ff-b2a3-1bc8" targetId="105350a0-544c-d1a1-ca88-fb5a883415ce" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a567e325-4907-1e0f-0a93-b2e3f562a1f8" name="Daemon of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="b39e1b4c-3c91-0591-9894-886c33200f3d" name="Hatred (Daemon of Nurgle)" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="bbc6fb08-e389-b97e-43f3-e221fc7154c0" name="Tzeentch Psyker Powers" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="3954ae34-dad8-8faa-8abd-7f4e53da2409" name="Re-roll all Saving throws results of 1" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="ebd1-098a-3816-e728" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ba33-2fc1-f7a3-0992" targetId="179e20b2-b985-74fe-b514-8f6da2e8dea3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="3bc2-20f7-a09f-3be4" name="Daemon Prince" points="0.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="adde-1f04-61bf-b39c" name="Must Choose One:" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="993e-16ca-67f0-e12c" targetId="96fb-4c60-2a63-3e5d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="617a-017e-3d43-da2f" targetId="e272-3cf0-8c8b-70de" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="560f-6d09-b5ab-b681" targetId="5bf8-d122-c25f-e889" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="79fa-810d-2510-d7fc" targetId="1489-43b7-64bb-2164" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="e272-3cf0-8c8b-70de" name="Daemon Prince of Khorne" points="160.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="db71-28fa-0e47-e89a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemon Prince" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="8"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Flying Monstrous Creature (Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="3+" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="6ece2600-dc3e-467f-8971-57f48ae89a58" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="abcd-ca4e-1e21-ba41" targetId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="fb40-1aaa-a521-8009" targetId="6ece2600-dc3e-467f-8971-57f48ae89a58" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="122b-a084-b882-7f14" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="98b6-f389-f1da-cb2e" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="12e0-9327-1eb3-8e12" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="3af4-dc69-161a-7c16" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="d633-e8ec-269c-7456" targetId="d628-f2bf-5d9e-bb65" linkType="entry group">
+          <modifiers/>
+        </link>
+        <link id="618d-2ef3-a0c2-10e1" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="5bf8-d122-c25f-e889" name="Daemon Prince of Nurgle" points="160.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="89ec-5c72-ffc3-c242" name="Psyker" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="9e4e-a081-7407-2814" name="Mastery 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="da99-c48f-e02e-8ff0" name="Mastery 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="29cd-c655-c433-174b" name="Mastery 3" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="211a-2b0c-d065-b017" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemon Prince" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="8"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Flying Monstrous Creature (Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="3+" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="6ece2600-dc3e-467f-8971-57f48ae89a58" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="a59c-0c49-99b1-cb15" targetId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="464b-4e35-5592-cee8" targetId="6ece2600-dc3e-467f-8971-57f48ae89a58" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b595-fe98-18d2-eb82" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b240-907b-412c-0a06" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ad46-89fe-49b1-da48" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b1dd-0a46-efab-c6e1" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="c972-85ef-5554-269e" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1489-43b7-64bb-2164" name="Daemon Prince of Slaanesh" points="155.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="42f8-ff65-27f2-e401" name="Psyker" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="c14f-cb97-54b9-da57" name="Mastery 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="eaf2-efe4-de10-3683" name="Mastery 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="8b3f-031c-8416-0f99" name="Mastery 3" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="751d-39c6-7bfe-c43b" name="Hellforged Artefacts of Slaanesh" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1775-1cdf-479c-6e90" targetId="1f57-87d5-c469-07e4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="b683-2f43-b2b1-6439" targetId="743e-8b4f-b3bf-9e9e" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="819c-49fd-3010-2a0f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemon Prince" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="8"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Flying Monstrous Creature (Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="3+" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="6ece2600-dc3e-467f-8971-57f48ae89a58" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="4780-5488-1a6b-c240" targetId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="a1e6-007b-48af-8a9e" targetId="6ece2600-dc3e-467f-8971-57f48ae89a58" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="58f0-183d-0f39-3c6c" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f728-64c0-b036-bfff" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5ddb-d4c8-9f98-3dc3" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="d822-32ff-c67d-7da8" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="d7ed-8575-0e9d-96e8" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="96fb-4c60-2a63-3e5d" name="Daemon Prince of Tzeentch" points="170.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4e6c-2697-06e0-6480" name="Psyker" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="2507-d7ac-2baa-ac90" name="Mastery 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="e9f2-7754-a359-1945" name="Mastery 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="eeb0-a4cb-5ca8-1f45" name="Mastery 3" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="77eb-641c-2318-6413" name="Hellforged Artefacts of Tzeentch" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="2910-29f3-cbfe-eead" targetId="4a04-a0cf-79ff-494d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="18dc-2b94-53bf-2ad2" targetId="9385-e312-79ca-71a0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="a9e6-8df0-c156-b3f6" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemon Prince" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="8"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Flying Monstrous Creature (Character)" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" value="3+" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="6ece2600-dc3e-467f-8971-57f48ae89a58" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="37eb-8c10-cc1a-ad9e" targetId="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="b2d7-712f-4720-f438" targetId="6ece2600-dc3e-467f-8971-57f48ae89a58" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="8f93-395d-05eb-d600" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3fc7-5272-ec3f-6b40" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6f1a-d790-5c4c-31dc" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="098c-d780-2dc4-015e" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="3b74-5fee-aaaa-829e" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="4238-f87d-1eec-8d86" name="Daemonettes of Slaanesh" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="01ae-db1f-a7a3-8773" name="Daemonettes" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="10" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="3890-85df-5049-2b63" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemonettes of Slaanesh" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="a8a9-f58f-d2b6-0f06" name="Upgrade one Daemonette to Alluress" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="6d55-7716-5cd1-01f3" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Alluress" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="16b3-d9fa-13d2-65ca" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="5636-f484-d5c1-b174" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="5f5d-8a45-b834-ee40" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="b97a-f918-d8b2-15f7" targetId="9d5d757f-9ab5-403a-4b68-4766f397bbbb" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="abd5-3208-b266-7dbb" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="70d5-4280-ed51-8e35" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="765d-ec98-cb0f-fa9a" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="21e8-b8dd-370f-7ac1" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="3ea18292-e8be-46a0-77c2-4a3b7e8aa16b" name="Daemonic Flight" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="97d8a80a-2d65-80d4-e100-4fea886c32b6" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Daemonic Flight" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Monstrous Creatures with this Gift are Flying Monstrous Creatures.  Other models with this Gift add Jump to their Unit Type."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="2e05-c038-f146-2fcb" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8eb9-f254-6303-3d3c" name="Daemonic Heralds" points="0.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="fe6e-e756-5441-9eb7" name="Type of Herald" minSelections="1" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="2fbe-f488-1d89-0ef4" targetId="eff5-c688-5678-5765" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="96b4-836a-a3ac-5180" targetId="2f67-49b4-2d18-024c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="39e5-f747-80eb-dbab" targetId="7e71-1691-295a-6121" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="5dac-19dd-ebc6-81f2" targetId="68cf-71eb-8c4c-320b" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="0654-947c-d252-e188" targetId="7651-7d14-ae01-f5a5" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="71fc-244b-4d1c-cd86" targetId="a30c-2d37-8e65-3993" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7e94-cdcc-a54d-daae" targetId="a5d2-c03a-c9d8-8e2a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="421f-8859-2b0b-784e" targetId="cecc-a6c2-65b8-5f8c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="5d02-58e1-7d6c-66e4" targetId="eeb8-23a2-fd50-af88" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="07ddce08-173c-9cf4-47d2-bc017205d59c" name="Daemonic Psyker Level" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="2cdb-3235-f37b-4f24" name="Death&apos;s Head of Duke Olaks" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="ba05-c02e-4d8a-c782" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Death&apos;s Head of Duke Olaks" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Large Blast, Poison 2+, One use only."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="69c6-5dab-8b48-383e" name="Deathdealer" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="25">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="fe0e-4ead-55dd-db9c" name="Searing Gore" hidden="false" book="Scions of the Warp" page="25">
+          <description>Each time a model is removed as the result of an attack by this weapon, its unit immediately suffers an additional D3 S3 AP4 hits. Wounds caused by these hits are allocated starting with the closest target model to bearer.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="5806-ac27-a461-c277" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Deathdealer" hidden="false" book="Scions of the Warp" page="25">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Decapitating Blow, Searing Gore, Specialist Weapon"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7ae1-da27-0feb-d5c7" targetId="28e85a6b-69ef-5afb-7c92-32decbc0dc0a" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="467c-732a-4314-9fed" name="Epidemia" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="83b7-30b3-21fd-3c4e" name="Mass Contagion" hidden="false">
+          <description>Each time a model is removed as the result of this weapon, its unit must pass a Toughness test or suffer an additional wound with no armour or cover saves allowed.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="cbdd-9819-dc8d-f199" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Epidemia" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Specialist Weapon, Mass Contagion"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="e61c-6129-212e-2143" targetId="e002-c436-5f54-4f00" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a30c-2d37-8e65-3993" name="Epidimius" points="110.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="1c82-96e2-9761-22c9" name="The Tally of Pestilence" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="1ccc-b33e-3e45-0721" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Epidimius" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="08ac-f00d-0ae0-d533" targetId="e20bdf1a-af78-1737-876b-d951aa7ad3eb" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="903a-60ce-4ac8-f322" targetId="e76a75c1-2f6b-bc2e-b2d7-1270ae51514f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="f641-0e50-b40e-e614" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5559-dd90-5800-bfb0" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c412-3dbc-5fc5-ccc0" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="adf5-06e0-de13-9eff" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="21c5-1fcb-7c34-58cb" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d6ab-5ca7-27f7-6982" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1d19-7102-05cd-5d1f" name="Exalted Alluress" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="06b5-a332-476e-9c91" name="Hellforged Artefacts of Slaanesh" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="d2a3-2dbf-27c0-53f7" targetId="65ea-60d1-b848-aa53" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="3785-6360-a703-9aab" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Exalted Alluress" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="49fe-ba72-d74f-6880" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2172-1422-c0c2-0d9b" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="a5d2-c03a-c9d8-8e2a" name="Exalted Flamer of Tzeentch" points="50.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="950d-c321-b0e5-a06d" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Exalted Flamer" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-/5++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="8a9c-7914-8b2d-883e" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a14d-e021-f554-6f1f" targetId="de070752-2c93-5c2c-d937-5cab4ff68531" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="45a2-1086-679e-617d" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7df9-4a26-3068-d594" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="94e5-6e79-1b4e-6bb8" targetId="8701-9490-8c77-dfcf" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="0aa2-36e7-f88d-5fed" targetId="ac4e-94da-4bb7-7c2f" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="40debf19-f2ad-becd-81f4-699c4fe513c4" name="Exalted Locus of Beguilement" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="f167db00-eae6-97aa-5497-85390c2e281f" targetId="f0572e80-c3a6-3df8-f98d-2e5a8f74c149" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="d4ed832d-7bda-1f28-fcb7-6c1dfd09a70e" name="Exalted Locus of Conjuration" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="9a3e1699-3445-1e0f-ebef-b2bda820de21" targetId="d22adfca-34c9-d6ca-034b-c5e21dc08d46" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="bfd50561-6c39-a235-0fdd-d8f348a600b0" name="Exalted Locus of Contagion" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="0889227d-c2f1-1be3-74e9-2fabf866ba46" targetId="f8950615-4df3-152e-9f8f-6308a078b6a5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="17533900-ae42-e9a3-cd9d-09dcf482c81c" name="Exalted Locus of Wrath" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="625be167-22ba-c6dc-14ce-ec385ce3a7ad" targetId="447c353f-26f0-87cb-1ee9-8aacf4ca6311" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b4d2-7350-2032-404d" targetId="24b5d0f6-4d76-38fb-46a5-15af6e009f4b" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0395-862f-a203-d823" name="Exalted Seeker Chariot of Slaanesh" points="75.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4c02-8594-06ec-40af" name="Exalted Alluress" defaultEntryId="cd3f-fcc1-6d44-4126" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="cd3f-fcc1-6d44-4126" targetId="1d19-7102-05cd-5d1f" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="99d8-d869-66a3-f3bd" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Exalted Seeker Chariot of Slaanesh" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="97b2-2b67-f2c1-bc17" targetId="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b276-3ae0-8d1b-9cc3" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3523-a501-d5c9-4ae1" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="ef6c-d947-4eaf-1387" name="Fiends of Slaanesh" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="16ff-3a54-df8a-91f7" name="Fiends" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="f918-dad2-4fe1-3a63" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Fiends of Slaanesh" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beast"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="47a2-a3ef-c558-2dc0" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2395-e4bc-eaf8-e28a" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5f7f-9e13-1739-8cbd" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="77c2-809e-8f95-0e9e" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="0d1c-de0b-6f72-3c58" targetId="e3c5b8e4-c498-8b45-8ca0-7ed4926593af" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="685156ec-d040-61a1-65e7-cf5ba676de3f" name="Fighter Ace" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="f9ac-68da-824f-9d4f" name="Fighter Ace" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="5c3a-0f55-df92-83e0" name="Flamers of Tzeentch" points="0.0" categoryId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="e407-1ea5-659c-5858" name="Flamers" points="23.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="4b21-6282-79c9-246f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Flamers of Tzeentch" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump, Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="bdce-1a61-b758-4a1d" name="Upgrade one Flamer to Pyrocaster" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="1168-0ef4-67ab-b7ac" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Pyrocaster" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="dfbb-8b44-7a7c-96e1" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="c95d-7918-08ed-970d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Flames of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault1, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="8ec8-f9ba-b077-1a8e" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="7ddd-a920-85ee-91b2" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="2da6-79ca-9a18-192a" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8093-5085-93d9-1b2d" targetId="de070752-2c93-5c2c-d937-5cab4ff68531" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="d5e01c3c-2df1-41a2-522b-f10a78922850" name="Flames of Tzeentch" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="5bcc253e-f437-4071-bcef-a352438d9997" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Blue Fire of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="18&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy D3, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="75c0c8a5-10d4-7948-ee55-9f8780afe358" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Pink Fire of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Torrent, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="f2624f18-d550-0c1d-ec7f-5cb8103efbed" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Flames of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault1, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="e0b0-ac29-3689-5cd0" name="Flayertroupe" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="bda1-eae8-af0e-45a2" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a777-8ac0-0bca-68d4" targetId="3e57-8b86-1e1f-e2fd" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="063f-2423-b5d1-1b2a" targetId="68cf-71eb-8c4c-320b" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="8862-779f-e7b8-8acd" name="Units" minSelections="6" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="f747-5396-1042-f2d4" targetId="4238-f87d-1eec-8d86" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="ae27-db6c-82a1-1a88" targetId="ef6c-d947-4eaf-1387" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="ca3b-bf81-c677-b3ae" name="Beguiling Chimes" hidden="false">
+          <description>Enemy units that are locked in combat with any units from a Flayertroupe reduce their WS and I by 1 (to a minimum of 1).</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="acf7-c1b9-2d0e-d5c1" targetId="df05-1da8-c69d-c24c" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="3f80-0d32-7480-5131" name="Flesh Hounds of Khorne" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="4e4d-a45d-7df4-c7e6" name="Flesh Hounds" points="16.0" categoryId="(No Category)" type="upgrade" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="2b3d-bc0c-04c0-f39c" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Flesh Hounds of Khorne" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beast"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="8681-6509-7271-b079" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="9c86-f18a-58a0-dc4f" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3228-8bd5-5edf-54ad" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3d7a-7138-4e14-8551" targetId="6cf163f7-da38-2d67-9b2b-dba71fcbfa6a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="43f0-1f7b-2f9e-50a8" targetId="925fc93b-51ed-95bb-4d26-e27055d1857f" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0899-4ef9-27d7-b992" name="Forgehost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="9557-47b0-fc38-9860" name="Soul Grinders" defaultEntryId="189e-5d2d-36dd-24a0" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="189e-5d2d-36dd-24a0" targetId="aebb-848c-24c3-ccd8" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="9267-5f77-6374-eece" name="Desperate Competition" hidden="false">
+          <description>Each time a Soul Grinder from a Forgehost inflicts any enemy casualties during a Shooting or Assault phase, all other models from the same Formation can re-roll all failed To Hit and To Wound rolls until the end of that phase.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="034114c1-262b-4a89-ac3c-4b293da58a3b" name="Fury of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="73c9-9002-be8b-0135" targetId="105350a0-544c-d1a1-ca88-fb5a883415ce" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="d28f-a8b9-6af1-ae20" name="Gorethunder Battery" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="82bc-c5f9-588e-fc66" name="Skull Cannons" defaultEntryId="02b9-e664-fa6d-1ade" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="02b9-e664-fa6d-1ade" targetId="003f-11f8-f5df-a9c7" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="aa8c-fc1a-aa34-6e90" name="Herald of Khorne" defaultEntryId="054f-e4ec-9dc9-c78a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="054f-e4ec-9dc9-c78a" targetId="eff5-c688-5678-5765" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="e0b5-365f-321f-5f87" targetId="2815-f85c-fa92-9679" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4128-4135-b85f-b237" targetId="28a8-aef7-82fa-61d1" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4959-cd8f-f8ac-e219" targetId="2141-b904-3142-747d" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="4007-b0dd-6642-d429" name="Grand Cavalcade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="9b8f-b1d3-be68-fdc6" name="Units" minSelections="6" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="d58a-42e3-18fa-276b" targetId="2ba5-dc49-9624-6220" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="21a9-a23c-3310-5195" targetId="1b3b-5b77-f87a-3fc2" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="31ae-5bc5-06e6-7390" targetId="11ed-c0dd-7520-27e0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="b605-5eb1-eef9-b688" name="Herald of Slaanesh" defaultEntryId="e12e-22a6-40a8-0acc" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="e12e-22a6-40a8-0acc" targetId="68cf-71eb-8c4c-320b" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="78ca-0cad-64ea-50e9" name="Eager for the Slaughter" hidden="false">
+          <description>All Grand Cavalcade units can move an additional 6&quot; when moving Flat Out or making Run moves.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="14f9-0d11-d2b1-4401" targetId="df05-1da8-c69d-c24c" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f714-0bc5-7ea7-6716" name="Great Axe of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="0ecc-4870-3fee-f1ee" targetId="fc19-5b2f-9692-efac" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="fad7-5706-1aaf-509c" targetId="cb53-fc30-9e5c-3240" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="bb4d-dbfa-7136-7bdb" name="Great Unclean One" points="190.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="2c41-15ac-b99d-3361" name="Psyker Levels" defaultEntryId="29d1-184d-a11b-4dae" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="615d-5217-4576-1674" name="Psyker Level 2" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="29d1-184d-a11b-4dae" name="Psyker Level 1" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="6848-7165-41f8-b167" name="Psyker Level 3" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="d045-bb29-c79f-ebeb" name="Hellforged Artefacts of Nurgle" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="c838-34fb-fbec-45d0" targetId="806f-9bf2-b5ad-cc58" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="8395-6393-a128-65f4" targetId="9b31-146b-abbc-344c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="b6fc-92e9-2bc0-a54f" targetId="467c-732a-4314-9fed" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="ce02-3e1c-42e3-50a7" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Great Unclean One" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="7"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="2f5e-3b71-683c-751b" targetId="6ac2f44f-d25b-8ea5-d36a-5f2267ad7613" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="59a3-850c-fadc-aab1" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1a7e-3485-aa4d-f7bf" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6bd3-5630-fba4-1678" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="70fb-c927-07a5-b226" targetId="8d6f4c07-9f52-8cd7-4b85-72716d063bf4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="bec1-43e7-6da4-4d58" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="340d-214b-c4cf-badb" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="d3d8728d-8655-6472-a8fc-0dca1f5dcf7a" name="Greater Locus of Change" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="87de3481-d984-f0c7-e190-dee95d8085d8" targetId="7234cfd3-7878-6c3c-4d8c-bb4ba71fbd98" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="0ff72112-a688-fb93-815c-992eb420559d" name="Greater Locus of Fecundity" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="cea5ec08-be1f-02a3-3258-f7aee8702132" targetId="8451920b-8b38-134a-3b16-7c65e7c26429" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="13c9-f821-6323-bf98" targetId="bc27e394-d6c3-024b-4eab-144dd9379571" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="6f3aa57b-2e4d-8df3-d7fd-f1d7d3b6b0ef" name="Greater Locus of Fury" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="9d9b69b0-95ca-697d-ed8c-ed22ef88cdb1" targetId="95e8f813-4b22-1f94-f566-0dcc3bcf6bfa" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b279-6d08-34e9-df7a" targetId="41b0-7f97-46cb-d026" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="f4419e49-d65d-93f4-f8dc-bfd46c2db717" name="Greater Locus of Swiftness" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="cef423fe-d5cd-9ec5-ff86-e418b470603f" targetId="390061fa-2828-9c86-a55e-8cf1ab4b7c3f" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="806f-9bf2-b5ad-cc58" name="Grotti the Nurgling" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="3e88-c402-5b85-8cc0" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Grotti the Nurgling" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Reduce the T of all models, friend or foe, by 1 whilst they are in 6&quot; of a model accompanied by Grotti, unless they are a Daemon of Nurgle. "/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="1b3b-5b77-f87a-3fc2" name="Hellflayers of Slaanesh" points="60.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="35a9-e3d8-3b0c-4266" name="Exalted Alluress" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="0e62-f678-73d8-6a3b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Exalted Alluress" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="a786-851c-8b34-c409" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="f830-0c43-3dc9-f064" targetId="981a0462-d81e-8e26-a50e-c9784942f952" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="335a-1b3c-fd01-3b85" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Hellflayer Chariot of Slaanesh" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Fast, Open-Topped"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="76b3-47f8-1386-49d4" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e0a9-907c-cc3f-724a" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e93a-136d-d99f-959e" targetId="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="eff5-c688-5678-5765" name="Herald of Khorne" points="55.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="033d-f678-1b64-fde0" name="Daemonic Steed" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="dff1-cd48-10c9-b86a" name="Juggernaut" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="category" childId="d28f-a8b9-6af1-ae20" field="selections" type="at least" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="feec-07a0-fb61-92d9" name="Blood Throne of Khorne" points="75.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="category" childId="d28f-a8b9-6af1-ae20" field="selections" type="at least" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules/>
+              <profiles>
+                <profile id="92b3-e3b0-8dc6-a70b" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Blood throne of Khorne" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+                    <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="12"/>
+                    <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+                    <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                    <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Open-Topped"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="982b-01ba-d2bc-59b7" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="20cd-be26-d5c0-d610" targetId="d0ca56e6-0fc6-1592-3364-7e44a1e6425f" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="226f-6eec-15de-3470" targetId="18f7a4e9-db49-40a2-4cd9-45c37538a3eb" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="8615-2c6b-70c2-05e0" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="b57e-4af0-c0d6-0bc6" targetId="5cb054a3-97b5-4578-dd3e-f69e2ef5b170" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="92d7-1d15-e6b5-5964" name="Daemonic Loci" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="2707-eb7d-0ef8-f9af" name="Lesser Locus of Abjuration" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="be09-a308-c79d-0869" targetId="fbb667d5-8f46-f433-9656-f173a7abc283" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f587-a317-95d5-5e8b" name="Greater Locus of Fury" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="0d3e-58a6-ccf1-f96f" targetId="95e8f813-4b22-1f94-f566-0dcc3bcf6bfa" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="b257-2cc6-22a8-eead" name="Exalted Locus of Wrath" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6b38-6bca-0359-6dee" targetId="447c353f-26f0-87cb-1ee9-8aacf4ca6311" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="be5a-f088-d8bb-2eaa" name="Hellforged Artefacts of Khorne" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="66c8-7ad9-6a5f-a74a" targetId="65e3-2ded-3ff6-cd8d" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="e2b4-f129-590c-8d47" name="Weapon" defaultEntryId="a7e2-aa08-469c-ca66" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="a7e2-aa08-469c-ca66" name="Hellblade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b063-3160-979c-b313" targetId="2f692f01-8637-a8c7-de2c-23060a63958b" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="6419-d7ff-bee2-bb89" name="Hellforged Artefacts" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="d062-dbd5-0541-aee2" targetId="210c-b684-6cd6-7bc3" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="e63b-2eca-2618-0cef" targetId="72cd-767c-468a-ed69" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="7400-11ca-165c-fbc0" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Khorne" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="7"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="eff5-c688-5678-5765" incrementChildId="dff1-cd48-10c9-b86a" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="true" numRepeats="1" incrementParentId="eff5-c688-5678-5765" incrementChildId="dff1-cd48-10c9-b86a" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" value="1" repeat="true" numRepeats="1" incrementParentId="eff5-c688-5678-5765" incrementChildId="dff1-cd48-10c9-b86a" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Cavalry (Character)" repeat="true" numRepeats="1" incrementParentId="eff5-c688-5678-5765" incrementChildId="dff1-cd48-10c9-b86a" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="476b-ce78-45bd-873a" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers>
+            <modifier type="hide" field="name" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="eff5-c688-5678-5765" childId="feec-07a0-fb61-92d9" field="selections" type="at least" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="c21d-ad84-3a02-11df" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="31ec-1bf0-682c-4f80" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b03a-0043-be0b-b25f" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="6261-b9aa-4f0f-c3a4" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="46a1-90de-75f9-6b51" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="7e71-1691-295a-6121" name="Herald of Nurgle" points="45.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="7329-1ea1-af3a-ef4c" name="Palanquin of Nurgle" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="c2ff-999b-b395-fa14" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="9c6a-b3b3-b8c5-5124" name="Daemonic Loci" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="5b4d-21d7-db34-6610" name="Lesser Locus of Virulence" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="4634-cc26-9c4a-d572" targetId="e8614f30-7c26-21f0-74c0-ea5b73c18bb3" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="22a7-c3c3-8f3b-ce99" name="Greater Locus of Fecundity" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="82b7-e587-5762-be73" targetId="8451920b-8b38-134a-3b16-7c65e7c26429" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="d2cb-51eb-73eb-f8bb" name="Exalted Locus of Contagion" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="5591-1cc5-5c6d-ed97" targetId="f8950615-4df3-152e-9f8f-6308a078b6a5" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="012e-4cdc-0b8c-433d" name="Daemonic Psyker Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="b477-aee5-fab6-b7aa" name="Psyker Level 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6167-d065-e21e-5fcd" targetId="8d6f4c07-9f52-8cd7-4b85-72716d063bf4" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7b91-10c2-0cee-e477" name="Psyker Level 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="61f6-7066-616d-0b7d" targetId="8d6f4c07-9f52-8cd7-4b85-72716d063bf4" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="2b5e-3b48-fcca-a6e6" name="Hellforged Artefacts of Nurgle" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="8144-26bf-ee4e-6e0b" targetId="806f-9bf2-b5ad-cc58" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="3fdc-53c1-915d-c772" targetId="9b31-146b-abbc-344c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="dec7-4c3f-1d1d-e07f" targetId="6538-5d1c-0256-5506" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="c67a-7391-e7bf-07de" targetId="2cdb-3235-f37b-4f24" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="908a-22d3-3415-dc9f" targetId="6f54-3dec-116a-d38a" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="2a63-0854-b819-5b16" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Nurgle" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" value="2" repeat="true" numRepeats="1" incrementParentId="7e71-1691-295a-6121" incrementChildId="7329-1ea1-af3a-ef4c" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="7e71-1691-295a-6121" incrementChildId="7329-1ea1-af3a-ef4c" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="1030-310f-9ad3-7f07" targetId="e20bdf1a-af78-1737-876b-d951aa7ad3eb" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="2254-37ff-7224-2380" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3b7a-ce28-209e-d8c5" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="76cc-a893-690e-2275" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8e00-a9d2-b4ee-98b7" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a0d3-0135-bfad-a021" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="0d21-398b-f45b-3a28" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="68cf-71eb-8c4c-320b" name="Herald of Slaanesh" points="45.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="ce1c-941d-8cdd-bdc0" name="Daemonic Steed" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="07e0-74db-89f4-6e14" name="Steed of Slaanesh" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1d6e-2976-6ec4-fc87" targetId="aa6d7d3a-ce11-ed0b-eb26-d6b474143773" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="29d6-28a4-6a7a-372f" targetId="207c581a-edbb-e35f-ddb8-b4442e0b1184" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="7079-f0cd-5ef3-6215" name="Exalted Seeker Chariot of Slaanesh" points="80.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="5886-638c-ce47-918e" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Exalted Seeker Chariot of Slaanesh" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+                    <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+                    <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                    <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="2471-2eb9-c5b6-aa82" targetId="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="fd69-0ea1-c51b-0d76" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="80c7-9950-d77b-8a7f" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="12b3-6f04-215e-e107" name="Seeker Chariot of Slaanesh" points="30.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="fdf3-2b24-5f13-db19" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Seeker Chariot of Slaanesh" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                    <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+                    <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+                    <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                    <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="d15e-c2fa-d5ad-ba93" targetId="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="7004-56f3-67ee-b3be" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="25cd-ff7c-0aac-2e66" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="category" childId="4007-b0dd-6642-d429" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links/>
+        </entryGroup>
+        <entryGroup id="87be-2b7e-147b-6927" name="Daemonic Loci" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="790b-8a58-996e-640d" name="Lesser Locus of Grace" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="e55a-ba2f-8f07-fcb9" targetId="53e054c0-d3ed-590a-5d77-db1cf45742ce" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="68c6-8436-1cd5-5080" name="Greater Locus of Swiftness" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="8841-fe70-adbf-857d" targetId="390061fa-2828-9c86-a55e-8cf1ab4b7c3f" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="5c81-94f6-dacc-5bc6" name="Exalted Locus of Beguilement" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="bf43-96ea-94bd-80c6" targetId="f0572e80-c3a6-3df8-f98d-2e5a8f74c149" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="82b4-3443-5c4b-c9e9" name="Daemonic Psyker Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="dd33-dd11-5b33-c617" name="Psyker Level 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="a4c2-1761-a96b-a05a" targetId="5c742f7d-fd81-ee06-4793-5f99e25f4aab" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="dde6-4aa0-7b28-0eff" name="Psyker Level 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="6cf4-c477-c50f-0a1c" targetId="5c742f7d-fd81-ee06-4793-5f99e25f4aab" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="dc17-ab5b-c5ea-3b98" name="Hellforged Artefacts of Slaanesh" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="012f-51de-0c77-2d66" targetId="1407-a19d-0d8a-eabd" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="86a9-1c2a-32a8-05ed" targetId="bd52-2e0c-0ea5-59cb" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="01a5-4f9f-835c-92aa" targetId="89f7-4bf0-c3aa-e1d0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="9116-c060-c246-a3ea" targetId="743e-8b4f-b3bf-9e9e" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="75b1-2592-e145-228b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Slaanesh" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="7"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="68cf-71eb-8c4c-320b" incrementChildId="07e0-74db-89f4-6e14" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Cavalry (Character)" repeat="true" numRepeats="1" incrementParentId="68cf-71eb-8c4c-320b" incrementChildId="07e0-74db-89f4-6e14" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="2" repeat="true" numRepeats="1" incrementParentId="68cf-71eb-8c4c-320b" incrementChildId="1407-a19d-0d8a-eabd" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0e9d-d437-3b36-6e4f" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="413c-73e7-3fa6-a40e" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9c6b-2946-c1f6-6406" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="00be-5c8b-ce67-5588" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4b98-76ff-cda9-42b6" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1906-21d2-0dea-ee2f" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="eeb8-23a2-fd50-af88" name="Herald of Tzeentch" points="45.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="0756-9ecd-4540-3f69" name="Daemonic Steed" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="44f7-1b4b-b200-42e1" name="Disc of Tzeentch" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="6b37-3100-58ed-12d7" name="Burning Chariot of Tzeentch" points="50.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="fa90-31d7-e305-9fe9" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Burning Chariot of Tzeentch" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                    <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="10"/>
+                    <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="10"/>
+                    <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+                    <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Fast, Open-Topped, Skimmer"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links>
+                <link id="36e8-0837-bf00-412f" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="b172-9e1e-c9cd-68fa" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="890c-7908-6336-7fc1" targetId="add2bfb1-23e3-51d0-287b-1e4a6d4f4f19" linkType="rule">
+                  <modifiers/>
+                </link>
+                <link id="ab5d-0793-32a2-95e8" targetId="c9bc31d8-5209-01af-e962-cb637c6c9640" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="category" childId="77e0-abe4-f8f5-e6d3" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links>
+            <link id="1189-2667-ee43-e2bf" targetId="5df8-3d13-2131-21de" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="eeb8-23a2-fd50-af88" incrementChildId="2ded-e7c4-a7cb-6c5d" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="99a1-0223-4998-2a3a" name="Daemonic Psyker Level" defaultEntryId="2b66-3f2a-6d5c-663f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="2b66-3f2a-6d5c-663f" name="Psyker Level 1" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="9f2a-b139-d8bf-b81b" name="Psyker Level 2" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="e124-a00d-d971-fd07" name="Psyker Level 3" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="3417-f16c-0af3-b436" name="Daemonic Loci" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="82c2-da60-42f1-3a5a" name="Greater Locus of Change" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="42b2-202d-51c9-7626" targetId="7234cfd3-7878-6c3c-4d8c-bb4ba71fbd98" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="6f57-29aa-b419-d86a" name="Lesser Locus of Transmogrification" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="3632-38bb-0a1f-22ff" targetId="7fc4dafe-ecea-a8d2-8dc7-7cd1b58b6351" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="2f42-df95-559a-2ad9" name="Exalted Locus of Conjuration" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="afb9-0197-788d-27aa" targetId="d22adfca-34c9-d6ca-034b-c5e21dc08d46" linkType="rule">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="593a-bb12-ed50-8e29" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Tzeentch" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Jetbike" repeat="false" numRepeats="1" incrementParentId="eeb8-23a2-fd50-af88" incrementChildId="44f7-1b4b-b200-42e1" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="eeb8-23a2-fd50-af88" childId="44f7-1b4b-b200-42e1" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="eeb8-23a2-fd50-af88" childId="1189-2667-ee43-e2bf" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="eeb8-23a2-fd50-af88" incrementChildId="44f7-1b4b-b200-42e1" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="eeb8-23a2-fd50-af88" childId="44f7-1b4b-b200-42e1" field="selections" type="equal to" value="1.0"/>
+                    <condition parentId="eeb8-23a2-fd50-af88" childId="1189-2667-ee43-e2bf" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="5057-2ae6-934b-6f99" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="42ce-e587-5870-baf1" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="7f0e-54b0-a3d1-165a" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3902-4ef4-c00b-28d7" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6470-f332-ee10-8d86" targetId="057845e6-6ec3-8899-62b9-1576ba1891fc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cfc5-5350-b94b-1259" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="0c13-6193-3686-87e6" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="2ded-e7c4-a7cb-6c5d" targetId="6a22-750e-232d-a582" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="eeb8-23a2-fd50-af88" incrementChildId="1189-2667-ee43-e2bf" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="6538-5d1c-0256-5506" name="Horn of Nurgle&apos;s Rot" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="4edb-b41f-76bf-d421" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Horn of Nurgle&apos;s Rot" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="After resolving bearer&apos;s close combat attacks, add 1 model to friendly Plaguebearer units within 12&quot; of the bearer for each enemy model that was slain. Models must be placed in coherency and more than 1&quot; away from enemy models."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="3943-d478-17aa-78b5" name="Infernal Tetrad" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="15e3-77e9-60aa-47b9" name="Daemon Prince of Khorne" defaultEntryId="a332-f118-2440-78d2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a332-f118-2440-78d2" targetId="e272-3cf0-8c8b-70de" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="1392-76c0-6adc-189b" name="Daemon Prince of Nurgle" defaultEntryId="4238-70fe-9750-ae6b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4238-70fe-9750-ae6b" targetId="5bf8-d122-c25f-e889" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="f762-4be1-708b-af1b" name="Daemon Prince of Slaanesh" defaultEntryId="4d13-d37d-78a2-422c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4d13-d37d-78a2-422c" targetId="1489-43b7-64bb-2164" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="5e3a-1b63-b041-0eaf" name="Daemon Prince of Tzeentch" defaultEntryId="24af-4f6d-5075-f0a5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="24af-4f6d-5075-f0a5" targetId="96fb-4c60-2a63-3e5d" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="9323-5b44-c5cf-4453" name="Combined Might" hidden="false">
+          <description>The Daemon Princes of an Infernal Tetrad have the following benefits depending on how many of them are on the battlefield at the same time (the bonuses are cumulative):
+
+No. of Models	Benefit(s)
+4 Models	+1 T
+3 Models	+1 S
+2 Models	Re-roll failed To Hit rolls of 1
+1 Model	No benefit</description>
+          <modifiers/>
+        </rule>
+        <rule id="54cb-4546-404c-8a40" name="Shared Power" hidden="false">
+          <description>If your Warlord is chosen from this Formation, all of the models in the Infernal Tetrad also have that model&apos;s Warlord Trait, even if you chose to roll on one of the Warlord Trait tables in this book and they have a different daemonic alignment to your Warlord.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="1cd321b1-b131-875d-9d25-9929053cfd50" name="Instrument of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="f652-235d-3164-ce33" targetId="b9ac-931e-e950-bfe5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="34da-cb86-e965-3aec" name="Kairos Fateweaver" points="300.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="9fc6-4a9a-f92a-4d08" name="Warlord Trait:" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="760a-1f9c-8f2b-471a" name="Lord of Unreality" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="d6d1-cc11-74e1-4a09" name="Oracle of Eternity" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="8b0e-5381-d457-a289" name="The Two Heads of Fate" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="1fee-d727-d3fd-a5bb" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Kairos Fateweaver" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="1"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="7c8e-5e93-c6a3-b4d8" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Staff of Tomorrow" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Re-roll a single D6 once per turn.  Can be one of any 2D6, 3D6 etc rolls, but just a single D6."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0723-a588-b515-62a9" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="1e74-905b-5541-f4df" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="a35b-7d74-16aa-1eab" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a289-dfdb-376f-fdd9" targetId="057845e6-6ec3-8899-62b9-1576ba1891fc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3dbf-2ab2-2e9c-51b5" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="9d29-13d3-99f4-207a" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="7651-7d14-ae01-f5a5" name="Karanak" points="120.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="4bb1-eb1d-c83e-1ad9" name="Prey of the Blood God" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="a352-184d-c6be-72cb" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Karanak" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beast (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="6+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="c386-5769-c9ac-f44a" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Brass Collar of Bloody Vengeance" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="See Collar of Khorne.  In addition, any Psyker that takes a Psychic test within 12&quot; of Karank suffers Perils of the Warp on any double."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="840d-35ba-e45f-ffde" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="311f-a44f-c48f-ba7e" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="6888-27b6-6512-b2b0" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="339b-6590-8fec-92e0" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="46b7-6456-451c-a368" targetId="24b5d0f6-4d76-38fb-46a5-15af6e009f4b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="eaba-00a8-0e5a-f327" targetId="6cf163f7-da38-2d67-9b2b-dba71fcbfa6a" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f432-86b4-4850-36aa" targetId="6f3aa57b-2e4d-8df3-d7fd-f1d7d3b6b0ef" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="cec2-2722-6dbc-fffa" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="3fd5-1ea9-a52e-f350" targetId="925fc93b-51ed-95bb-4d26-e27055d1857f" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="cf2e-c247-0a75-6303" name="Keeper of Secrets" points="170.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="ad2c-bd65-68df-2cb0" name="Psyker Levels" defaultEntryId="4a42-f523-4f74-2018" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="e414-4feb-c948-0241" name="Psyker Level 2" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="4a42-f523-4f74-2018" name="Psyker Level 1" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="407f-9df1-2657-1dd5" name="Psyker Level 3" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="565b-b198-7200-a7ce" name="Hellforged Artefacts of Slaanesh" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="fed2-fa62-a870-1748" targetId="1f57-87d5-c469-07e4" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="4a2e-abc0-a40b-bfcf" targetId="1407-a19d-0d8a-eabd" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="7521-8d6a-1f16-8e6a" targetId="bd52-2e0c-0ea5-59cb" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="9e6b-bb31-6bfb-2008" targetId="743e-8b4f-b3bf-9e9e" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="0a32-ddad-176d-4142" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Keeper of Secrets" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="10"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="2" repeat="true" numRepeats="1" incrementParentId="cf2e-c247-0a75-6303" incrementChildId="1407-a19d-0d8a-eabd" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <links>
+        <link id="105c-031a-d851-e5b9" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d7f5-da8b-c501-9008" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8d27-4da2-5667-53c3" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e60d-77b9-a2ab-f324" targetId="843b0787-9074-2cd1-3aa1-d963f9ea4d51" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8c85-a324-9e0c-4739" targetId="5c742f7d-fd81-ee06-4793-5f99e25f4aab" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6042-ed5d-2aad-b121" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="088d-d900-6d75-4a9f" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="72cd-767c-468a-ed69" name="Khartoth the Bloodhunger" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="ec11-3337-c89d-2274" name="Sunderer of Time" hidden="false">
+          <description>When a model suffers any unsaved Wounds from this weapon, it is removed from play but make a note of where the model was. At the start of each of his turns, the controlling player rolls a dice; on the roll of a 4 or more the model re-enters play via Deep Strike within 12&quot; of the point from where it was removed. If the game ends before a model returns to play in this manner, it counts as destroyed.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="3042-20b3-916b-e0f0" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Khartoth the Bloodhunger" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Sunderer of Time"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="d8b0-0434-ac1e-6868" name="Khorne Lord of Skulls" points="888.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="83">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4c76-b199-fca8-2114" name="Hull Mounted Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="5214-bf38-cab8-1ba0" name="Gorestorm Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="85">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="0c99-c37b-1e3f-7ec5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Gorestorm cannon" hidden="false" book="Escalation" page="85">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Hellstorm"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Primary weapon 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="24f1-9d37-a268-b12e" name="Ichor Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="85">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="f95e-0c5f-af87-78bc" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Ichor cannon" hidden="false" book="Escalation" page="85">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Primary weapon 1, Large Blast"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="9d2a-5330-b111-0f66" name="Daemongore cannon" points="65.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="85">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="4aa4-a717-377d-cd3a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Daemongore cannon" hidden="false" book="Escalation" page="85">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Hellstorm"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Primary weapon 1, Gets Hot, Instant Death"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="1271-b49e-5666-ed8a" name="Arm Mount Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="d8e3-b15a-19fe-1566" name="Hades Gatling Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="85">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="d846-7a4a-e1e6-5c00" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Hades Gatling Cannon" hidden="false" book="Escalation" page="85">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 12, Pinning"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="ae7a-cf3f-ed46-4010" name="Skullhurler" points="60.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Escalation" page="85">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules>
+                <rule id="80ca-93be-e26b-d8b9" name="Gnaw" hidden="false" book="Escalation" page="85">
+                  <description>Successful saving throws against this weapon must be re-rolled.</description>
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles>
+                <profile id="8b04-0736-4627-aa44" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Skullhurler" hidden="false" book="Escalation" page="85">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="60"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Primary Weapon 1, Apocalyptic Blast, Gnaw"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="0e3e-71bd-27d1-fdf3" name="Daemonforge" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="55e4-d934-0d30-4d25" name="Fuelled by Rage" hidden="false" book="Escalation" page="84">
+          <description>For every Hull Point the Khorne Lord of Skulls has lost, it gains an
+additional Attack, even if that Hull Point is later regained (keep a note on your roster).
+Note that its Attacks characteristic cannot exceed 10.</description>
+          <modifiers/>
+        </rule>
+        <rule id="8081-3c8d-7bf2-ca08" name="Tracked Behemoth" hidden="false" book="Escalation" page="84">
+          <description>A Khorne Lord of Skulls may Tank Shock or Ram using the
+Thunderblitz table (see the Super-heavy Vehicles section), in the same manner as a
+Super-heavy vehicle, but it may not make Stomp attacks.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="fd2a-0146-45c1-8fbc" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Daemonic possession" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value=""/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="c3bb-1d47-72dc-0973" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Khorne Lord of Skulls" hidden="false" book="Escalation" page="83">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="10"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="9"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle(Super-Heavy Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="3c6b-1f8d-8b1c-a2bc" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Great Cleaver of Khorne" hidden="false" book="Escalaton" page="85">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="5855-f5fb-3130-45ce" targetId="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5377-1180-ec6f-27d2" targetId="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8c92-c3fb-0f5d-80df" targetId="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a075-e7f1-bad6-3d58" targetId="41b0-7f97-46cb-d026" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2932-5432-0a06-3738" name="Ku&apos;gath, The Plaguefather" points="260.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="72ef-556a-f08b-19ae" name="Daemonic Psyker Level 1" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="1af2-62a0-e6f1-3e80" targetId="8d6f4c07-9f52-8cd7-4b85-72716d063bf4" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="4fe4-7d4a-bd81-5ced" name="Warlord Trait:" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="1c65-d448-1a6e-4489" name="Immortal Commnader" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="432d-4fc4-5a29-63b0" name="Nurgling Infestation" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="ce1b-fd3f-3035-e3a9" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Ku&apos;gath, The Plaguefather" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monsterous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="7"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="7"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="1acf-288e-c260-4974" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Necrotic Missles" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="-"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Large Blast, Poisoned (4+)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="b5f0-a03a-78c2-7975" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="d514-21fe-b920-8395" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="768b-92f6-96b1-aa5a" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a262-4503-e624-2a87" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="8107-a3ef-8328-b837" targetId="ece8645d-de4f-c7a6-1031-2ea5d25d807f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c664-af73-2f16-da76" targetId="6ac2f44f-d25b-8ea5-d36a-5f2267ad7613" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9c0b-4f54-b1d9-0500" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="799770af-f51a-6d44-d51a-0ab301bd978c" name="Lesser Locus of Abjuration" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="bce99a48-7966-35ba-1d9e-15ab844eaeba" targetId="fbb667d5-8f46-f433-9656-f173a7abc283" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9269-41a5-97e2-fba7" targetId="d7f7-7923-faeb-8dc5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="fc9d4788-aaf6-73d3-5137-4ce1e5f67665" name="Lesser Locus of Grace" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="5cf599cf-70ff-bd28-9f0e-bd650265458e" targetId="53e054c0-d3ed-590a-5d77-db1cf45742ce" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9fe2-ea1e-0339-9b38" targetId="98304f1b-c1b0-f157-ca35-8d5a633cebbd" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="9b75f082-4d5c-8f8e-3c7d-a72b6d8d346a" name="Lesser Locus of Transmogrification" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="06202346-1a66-0bce-7a3d-4f39346d26bc" targetId="7fc4dafe-ecea-a8d2-8dc7-7cd1b58b6351" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="e76a75c1-2f6b-bc2e-b2d7-1270ae51514f" name="Lesser Locus of Virulence" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="121755ed-4493-25f1-7234-410d15f2e0cb" targetId="e8614f30-7c26-21f0-74c0-ea5b73c18bb3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="dac2-d0ef-2a14-4bb4" name="Lord of Change" points="230.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="4238-847a-76b8-a756" name="Psyker Levels" defaultEntryId="4095-a215-787f-c59b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="5c26-a0f6-3f80-ffa2" name="Psyker Level 3" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="4095-a215-787f-c59b" name="Psyker Level 2" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="cca4-7ab7-8aaf-4537" name="Hellforged Artefacts of Tzeentch" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="65f0-0121-cf07-5612" targetId="61ed-0386-f1a4-8cd9" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="794f-6414-2d9c-6f49" targetId="9385-e312-79ca-71a0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="b8aa-933c-ef87-21a3" targetId="eeb5-fded-337b-ae42" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="4cc4-8a47-3c79-2726" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Lord of Change" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="6896-2897-fb63-0c9a" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="40e5-6e36-407d-1d29" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="60f9-6ace-bda0-58c8" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="76d0-7688-7fed-c001" targetId="057845e6-6ec3-8899-62b9-1576ba1891fc" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8c9e-056d-a5cb-1128" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="2cee-6da1-e303-016f" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+      </links>
+    </entry>
+    <entry id="ce2721f1-f9e2-333c-5db8-aec9c13b34fb" name="Master of Sorcery" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="9cb6ca28-4a93-7b81-6135-785ddf317063" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Master of Sorcery" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The Model can use one extra weapon in its Shooting Phases (but not the same one twice, as normal)."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="9ef1-ea94-798e-830c" name="Murderhorde" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="a3ac-c345-c0e8-a91a" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="7914-d69c-0efd-e155" targetId="2f67-49b4-2d18-024c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="a291-0f3f-dfb0-9674" targetId="eff5-c688-5678-5765" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="beae-db4c-9da1-9e20" name="Units" minSelections="8" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups>
+            <entryGroup id="f705-1a96-346b-0682" name="Bloodcrushers of Khorne" defaultEntryId="8395-6ac4-90c1-1c9a" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="8395-6ac4-90c1-1c9a" targetId="158e-6391-7216-0921" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+            <entryGroup id="8cff-2ec6-8de4-cdf5" name="Bloodletters of Khorne" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="926d-b4d9-8791-f965" targetId="2fc2-d3c6-a640-8672" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+            <entryGroup id="6c69-b5b9-91dd-41fc" name="Flesh Hounds of Khorne" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <links>
+                <link id="6813-8a09-e2c2-3d2b" targetId="3f80-0d32-7480-5131" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="2566-fac5-5dcc-1400" targetId="aa11-a814-7133-fb3f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cce7-31ed-df92-c659" targetId="2815-f85c-fa92-9679" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="044f-5642-ff01-477a" name="Nurglings" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="d33e-ee7f-c01a-caa4" name="Nurglings" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="d3b0-83f8-99df-5bfc" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Nurglings" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value=""/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="a073-1fcc-e7fa-bb4c" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="c7d3-ab0c-199f-fdfd" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ead0-dd2b-6647-399b" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f02c-5586-4fd8-d80e" targetId="bcf33bb7-143c-199f-0e4a-b75b8abb71c6" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b0e1-5e97-8e42-0b64" targetId="7655d6a3-a37d-e989-7e1a-d9ab8c69e711" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="61ed-0386-f1a4-8cd9" name="Paradox" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="b211-7a7e-1ff8-6ceb" name="Warp Contradiction" hidden="false" book="">
+          <description>Once per turn, when taking Psychic test, the bearer can pick up and turn all dice he has rolled to their opposide side instead (ie 1, 3, and 5 become 6, 4, and 2).</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="33e6-93b3-4265-0622" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Paradox" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Concussive, Warp Contradiction"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="380b-4bae-ec21-8417" targetId="c64d-15e2-1e7f-9681" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a9cf-4334-0021-b8c1" name="Pink Horrors of Tzeentch" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="3447-cf24-ee8f-0115" name="Pink Horrors" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="10" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="3b09-19ea-7f9b-865b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Pink Horrors of Tzeentch" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="5e88-4bd0-e4c3-957e" name="Upgrade one Pink Horror to Iridescent Horror" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="1f55-996a-bd3f-5a0b" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Iridescent Horror" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="572f-f0bc-a5b3-6116" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="119b-458d-7826-7d5b" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="30fe-7eb6-e1b6-ff28" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="8feb-4eb8-e151-f520" targetId="54b7ec6d-44c0-56e7-ab13-aef0be6e9b83" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="4637-208a-4bc8-2a70" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5202-377e-7eae-d7c7" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="da45-2a23-a057-dee7" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3432-6228-0604-5719" targetId="4db62daf-117a-2864-1144-f39ea2f605c2" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="f1de-2c60-eefe-82eb" targetId="29d5b769-200d-1d40-5de9-9cc49983cd41" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b792-fb19-47f6-8564" targetId="ca5ce6c3-c53f-bcd2-b9ec-c35e5680ad35" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b1c0-404a-53c1-adcb" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="6043-884e-5827-1b32" targetId="057845e6-6ec3-8899-62b9-1576ba1891fc" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="51c3b1ee-a20f-4c86-7a5e-e9ba457fc548" name="Plague Banner" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="383b9ab4-803f-92bf-df66-bfe575a8a086" targetId="f5002729-935e-853f-0071-9a65b1d163ea" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="9f7c-472e-101e-c0e4" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="69ff-0427-3a47-5b25" name="Plague Drones of Nurgle" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="2dbb-806a-ea09-fc13" name="Plague Drones" points="42.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="32a4-19e7-bbb2-2ae8" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Plague Drone" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jet Pack Cavalry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="b10c-5c38-2fd0-4b5f" name="Icon of Chaos" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="73b0-d3ce-07eb-1ce5" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="15ef-c7d9-d490-060e" targetId="51c3b1ee-a20f-4c86-7a5e-e9ba457fc548" linkType="entry">
+              <modifiers>
+                <modifier type="set" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="5fcc-b08a-530c-b542" name="Upgrade one Plague Drone to Plaguebringer" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="cc86-8d5a-3e78-3875" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Plaguebringer" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jet Pack Cavalry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="cb2f-558e-a2b1-bce6" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="885d-c458-a193-5fdd" name="Death&apos;s Heads" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="69ff-0427-3a47-5b25" incrementChildId="2dbb-806a-ea09-fc13" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <rules/>
+          <profiles>
+            <profile id="6c85-cee2-d80a-9517" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Death&apos;s Head" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 2, Poisoned (4+)"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="2716-0164-199b-1bb5" name="Unit may take one" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="f64a-6a5b-0c5f-b7b8" name="Rot Proboscis" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="69ff-0427-3a47-5b25" incrementChildId="2dbb-806a-ea09-fc13" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules>
+                <rule id="ec32-fa43-ab19-ffec" name="Poisoned (3+)" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+            <entry id="971f-75f8-de56-4d75" name="Venom Sting" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="69ff-0427-3a47-5b25" incrementChildId="2dbb-806a-ea09-fc13" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <rules>
+                <rule id="e6ef-3ff1-3fde-9a63" name="Venom Sting" hidden="false" page="0">
+                  <modifiers/>
+                </rule>
+              </rules>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="e12b-6f87-2c23-1837" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4d16-65a8-5a83-3f1d" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="055a-8077-dd59-0cf8" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e375-992b-347e-3138" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="196c-2db1-3a2a-dd3a" targetId="55cd71e1-7772-3e2c-6ccd-d6274008f370" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="64e6-002b-3931-d99b" targetId="e20bdf1a-af78-1737-876b-d951aa7ad3eb" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="741d-4dac-a6fb-a523" name="Plaguebearers of Nurgle" points="0.0" categoryId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="7cee-b1d5-693b-a28d" name="Plaguebearers" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="10" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="d15b-4269-81b3-6cfa" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Plaguebearers of Nurgle" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="d709-3ad4-9793-187d" name="Upgrade one Plaguebearer to Plagueridden" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="e910-c447-519c-8d16" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Plagueridden" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="a7ad-ae69-f575-c666" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="beb3-f898-fcf1-ec45" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="da47-67d7-18b9-ad5f" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="6853-6aaa-dfef-5cfa" targetId="51c3b1ee-a20f-4c86-7a5e-e9ba457fc548" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="465b-8c3f-d821-7d3d" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="129b-6377-a90c-3582" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c8fd-1976-e720-1ac0" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="a2b7-0b75-f797-9378" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="39ce-899d-f2d5-acb6" targetId="e20bdf1a-af78-1737-876b-d951aa7ad3eb" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="9d5d757f-9ab5-403a-4b68-4766f397bbbb" name="Rapturous Standard" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="17d830bb-7fee-5a87-56c0-c4943039e3fe" targetId="0e35d665-ef26-d0db-1ab8-bfbbc044a347" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2572-b8b0-35d7-814a" name="Rotswarm" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="3802-ce4a-c14e-aba6" name="Units" minSelections="7" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="8382-18d1-f010-1743" targetId="69ff-0427-3a47-5b25" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="61b7-d38b-e9a9-41c0" targetId="b443-1a05-e312-2414" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="2cc1-f600-ea86-70d5" name="Herald of Nurgle" defaultEntryId="3abe-723e-05ec-9575" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="3abe-723e-05ec-9575" targetId="7e71-1691-295a-6121" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="8a53-057b-a797-c9dd" name="Corrosive Slime" hidden="false">
+          <description>All units in a Rotswarm have the Hammer of Wrath special rule, and these attacks have the Poisoned (4+) special rule.</description>
+          <modifiers/>
+        </rule>
+        <rule id="47b8-678a-81de-7d9c" name="Dubious Command" hidden="false">
+          <description>At the start of each of the controlling player&apos;s Assault phases, the Herald of Nurgle from a Rotswarm can attempt to direct a single unit from his Formation that is within 12&quot; of him. To do so, he must take a Leadership test. If the test is passed, the directed unit can re-roll failed charge rolls and all models in the unit can make 3 additional Attacks until the end of the turn; if the test is failed, the directed unit must attempt to charge the nearest enemy units in this Charge sub-phase, but is otherwise unaffected.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="b0d8-b3aa-90c3-eab8" targetId="d5e2-6fc6-b3b6-c187" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="ea39-f9f1-aa7c-a710" name="Scabeiathrax the Bloated" points="777.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="5d70-6e82-5744-926a" name="Nurgling Infestation" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="31c7-5705-19f9-24a0" name="Nurgling Infestation" hidden="false">
+              <description>Gains D6+3 extra attacks in CC using the profile provided.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="3956-1395-7a60-f9bf" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Nurgling Infestation" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="3"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Meele, Unwieldy"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="4ce9-9984-4789-eaae" name="Blade of Decay" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="2d86-9f0c-1149-9079" name="Contagion" hidden="false">
+              <description>A model that suffers an unsaved wound from a weapon with this rule must pass a toughness test or or suffer an additional wound with not armour or cover saves allowed.</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="9ed2-629e-1aa8-16ad" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Blade of Decay" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Meele, Contagion, Specialist Weapon"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="3282-cde4-571b-55fe" name="Icon of Chaos" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="53cf-1e39-abef-5582" name="Hulking Monster" hidden="false">
+          <description>May only move 6&quot; instead of 12&quot;</description>
+          <modifiers/>
+        </rule>
+        <rule id="69d8-1d0d-9970-2dbe" name="Maggotspore" hidden="false">
+          <description>Has feel no pain (4+) and is equipped with assault and defensive grenades. Gains +D3 attacks when charging. All models with a toughness value within 6&quot; at the start of the controlling players turn, that are not Daemons or have the mark of Nurgle,must take a toughness test or suffer a wound with no armour or cover saves allowed.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="ecd5-812b-a283-06b5" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Scabeiathrax the Bloated - Demon Lord of Nurgle" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Gargantuan Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="8"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="9"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-/3++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="1cc2-b980-6f86-0662" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Toxic Dishcharge" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Hellstorm"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7c73-0253-5108-9114" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2276-d1a3-a217-1da9" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="75d9-e646-af0c-0e8f" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="a804-526b-6f0e-ca78" targetId="4f9feb72-fede-03da-69d8-6efe86756bc3" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a608-a4d2-4e8b-0dc9" name="Screamers of Tzeentch" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="5e4f-7d93-beac-c8fd" name="Screamers" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="fd48-0188-500d-c536" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Screamers of Tzeentch" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jetbikes"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="1edd-fa4d-0cd5-144d" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6d3c-34d2-8beb-6d35" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4721-4857-f08c-20f4" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e48e-feee-bdf1-cccb" targetId="4aaf30a3-4dc7-1f26-3cf6-b0887870bbd9" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="ab6a-b430-33e3-f684" targetId="1009d9ed-1c9b-bc21-4ca6-f514fa3af669" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2ba5-dc49-9624-6220" name="Seeker Cavalcade" points="0.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="11b8-4663-e462-1c34" name="Cavalcade" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="b923-8c17-0e8c-a5ef" targetId="0395-862f-a203-d823" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="3b90-f3a2-fa0f-5239" targetId="826c-9f14-1095-00d7" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="826c-9f14-1095-00d7" name="Seeker Chariot of Slaanesh" points="40.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="d820-82fd-c706-51b0" name="Exalted Alluress" defaultEntryId="4a3d-1171-b41a-1eab" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4a3d-1171-b41a-1eab" targetId="1d19-7102-05cd-5d1f" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="6dcb-39c9-8114-f862" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Seeker Chariot of Slaanesh" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="7107-5364-5651-5900" targetId="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fe2f-ac18-eff2-aff9" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="66de-7977-4c16-3538" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="11ed-c0dd-7520-27e0" name="Seekers of Slaanesh" points="0.0" categoryId="c274d0b0-5866-44bc-9810-91c136ae7438" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="6760-51e4-b79a-bdce" name="Seekers" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="5" maxSelections="20" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="56e1-d395-cdf4-a4a9" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Seekers of Slaanesh" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Cavalry"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="37f1-af35-c640-5886" name="Upgrade one Seeker to Heartseeker" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="0fcd-8d9f-8474-b8a8" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Heartseeker" hidden="false" page="0">
+              <characteristics>
+                <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Cavalry (Character)"/>
+                <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+                <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+                <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+                <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+                <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+                <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+                <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+                <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+                <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="1d63-593c-541a-1eb6" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+              <modifiers>
+                <modifier type="set" field="maxPoints" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </link>
+          </links>
+        </entry>
+        <entry id="91eb-5aa7-4ec1-c61a" name="Icon of Chaos" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links>
+            <link id="4f4d-096e-4b0b-fe6a" targetId="9d5d757f-9ab5-403a-4b68-4766f397bbbb" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="b149-f32d-45ef-dd2a" targetId="42eb7a96-2072-b9bc-7700-f6b8f5e41564" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="f630-4378-4e9e-ecf6" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e47c-7a93-12a1-7933" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="08ef-f3ca-85f8-6613" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cd8c-954e-ed29-bb23" targetId="207c581a-edbb-e35f-ddb8-b4442e0b1184" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5c06-da1d-a60d-cc5b" targetId="aa6d7d3a-ce11-ed0b-eb26-d6b474143773" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="6758-9125-11a6-66ab" targetId="1cd321b1-b131-875d-9d25-9929053cfd50" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1407-a19d-0d8a-eabd" name="Silvershard" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="59f3-3acd-4630-93a3" name="Blade Blitz" hidden="false">
+          <description>Add 2 to the bearer&apos;s Attack characteristic.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="a6ad-0d36-601f-642a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Silvershard" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Blade Blitz"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="bac2-c4f5-3a15-4166" name="Skarbarand" points="225.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="03bd-1c28-fd6f-a7da" name="Warlord Trait:" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="01f4-e34c-0d8a-7fb0" name="Death Incarnate" hidden="false" page="0">
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="6814-42d3-61a9-7e54" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Skarbarand" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="10"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="10"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="d059-2de6-c9dd-1030" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Slaughter and Carnage" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Fleshbane"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="f95e-c11e-2603-2cea" targetId="13f0ca19-2aff-e3bb-e536-2be1b57f6bf2" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="ba19-bb80-2672-78f4" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2d65-bd9e-e149-3775" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="13f9-9acd-d2e7-e601" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5655-8391-959a-e39c" targetId="274da1cc-d0f3-8e8c-4ded-3d27931a934e" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="fa5d-8b71-ca93-ffb8" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="140f-8fff-6183-cba2" targetId="457d2aeb-5024-e443-db5e-8f81b7d231b0" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="003f-11f8-f5df-a9c7" name="Skull Cannon of Khorne" points="125.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="77f5-82cf-e432-c4d8" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Skull Cannon of Khorne" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="12"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Open-Topped"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="a058-5356-6a0b-2b4a" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Skull Cannon" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Dreadskulls, Ignores Cover, Large Blast"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="3fd4-3970-5083-a483" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="17cd-6923-7cd3-2cdc" targetId="18f7a4e9-db49-40a2-4cd9-45c37538a3eb" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="42de-772a-0a08-f155" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="bfec-98d4-1c32-efc7" targetId="5cb054a3-97b5-4578-dd3e-f69e2ef5b170" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c3f3-d730-e18b-399d" targetId="85a1-6c7f-aa19-be65" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="5c8a-f784-1e04-6a67" name="Skullreaver" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="06d6-3a8d-b7cf-031b" name="Anathema" hidden="false">
+          <description>To Hit rolls of a 6 are resolved at Strength D instead of the wielder&apos;s normal Strength value.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="6001-aee1-a1df-faa2" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Skullreaver" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Anathema, Specialist Weapon"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="5b51-4f49-6a8e-becb" targetId="e002-c436-5f54-4f00" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2f67-49b4-2d18-024c" name="Skulltaker" points="100.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="3a92-33e8-27b5-1b45" name="Daemonic Steed" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="030b-9387-605e-feab" name="Juggernaut" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="d194-c4c0-09e5-f367" name="Skulls for the Skull Throne!" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="dbf4-147d-3927-190a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Skulltaker" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="9"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="9"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers>
+            <modifier type="increment" field="3f9ed75c-36cd-4169-9cef-48391bb55cfd" value="1" repeat="true" numRepeats="1" incrementParentId="2f67-49b4-2d18-024c" incrementChildId="030b-9387-605e-feab" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" value="1" repeat="true" numRepeats="1" incrementParentId="2f67-49b4-2d18-024c" incrementChildId="030b-9387-605e-feab" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="5dff3e7c-e024-4030-a71d-03195ec06ea7" value="1" repeat="true" numRepeats="1" incrementParentId="2f67-49b4-2d18-024c" incrementChildId="030b-9387-605e-feab" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" value="Cavalry (Character)" repeat="true" numRepeats="1" incrementParentId="2f67-49b4-2d18-024c" incrementChildId="030b-9387-605e-feab" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </profile>
+        <profile id="27ca-6556-35ad-69d7" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Slayer Sword" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Decapitating Blow, Soul Blaze"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="6821-4d24-5edb-b85c" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Cloak of Skulls" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="This grants Skulltaker a 3+ Armour Save and the Eternal Warrior special rule."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="b4b7-dd75-f743-5ff2" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9136-3756-d0c8-f5d0" targetId="2f692f01-8637-a8c7-de2c-23060a63958b" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="ed1a-916f-3a24-8860" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="bedb-ce2f-571f-2d87" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4e09-b193-0287-6415" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="9d23-326a-aa4a-518b" targetId="799770af-f51a-6d44-d51a-0ab301bd978c" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="24f8-fcfc-14f8-313e" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="4a04-a0cf-79ff-494d" name="Soul Bane" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="7ce0-98ef-69e4-fb4b" name="Incorporeal" hidden="false">
+          <description>This weapon has an AP value equal to the target&apos;s Initiative value. Against targets with an I higher than 6, resolve Attacks from this weapon at AP-. Against vehicles, hits are resolved at AP1.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="115e-6c5f-f112-8b94" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Soul Bane" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="*"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Fleshbane, Incorporeal"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="2dbba0bf-d126-25af-85a2-b0506738fdb5" name="Soul Devourer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="a0381a4e-4a9b-0147-afa8-adaf8102238d" name="Soul Devour" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="44b07fb0-3e2e-7696-d85a-52cf4b0baa89" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Soul Devourer" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Soul Devour"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="aebb-848c-24c3-ccd8" name="Soul Grinder of Chaos" points="135.0" categoryId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="7eda-1b6f-0d07-9861" name="May take one of the following:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="d810-5528-ea07-0fac" name="Phlegm Bombardment" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="3123-e12c-253d-acd1" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Phlegm Bombardment" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 1, Large Blast"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="e0e1-e9c3-8832-1e22" name="Baleful Torrent" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="92a7-cd81-b105-208f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Baleful Torrent" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Torrent"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+            <entry id="c9f4-b53e-c740-fb2f" name="Warp Gaze" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="5cf9-5b7d-8ca2-6f7b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Warp Gaze" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="10"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="fc3d-9100-3cde-d262" name="May take:" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="619d-78f4-7644-c3d4" name="Warpsword" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles>
+                <profile id="7745-64c1-724c-55ed" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Warpsword" hidden="false" page="0">
+                  <characteristics>
+                    <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                    <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                    <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+                    <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Master-crafted, Specialist Weapon"/>
+                  </characteristics>
+                  <modifiers/>
+                </profile>
+              </profiles>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="1048-1f48-21e3-77c3" name="Must Choose one:" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="cc1f-489f-aceb-c346" name="Daemon of Tzeentch" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="1d8f-416f-90e6-1510" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="f826-46df-6778-1777" name="Daemon of Slaanesh" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="67ae-1372-5abc-4d65" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="4d8d-7b7a-7ac6-39da" name="Daemon of Nurgle" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="ed5b-8e79-1f9e-890d" targetId="bc47ebb1-051d-12f5-85f9-a2520a661c51" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="1cb4-c9ad-5bb8-3c2c" name="Daemon of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="ad74-7107-1aa9-e95a" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="809b-15b9-3ebe-7ce3" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Soul Grinder of Chaos" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+            <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+            <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+            <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Vehicle (Walker)"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="5b6e-88be-ed95-47a6" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Harvester Cannon (Flakk)" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 3, Skyfire"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="c9f5-d6c6-c628-078f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Harvester Cannon (Solid)" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="48&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 3"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="78ca-e6de-cd37-56a1" targetId="87adee1e-acae-74dc-0663-046470e4c144" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="c03b-b6a0-6125-a06c" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="1f57-87d5-c469-07e4" name="Soulstealer" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="c59d-56e5-d1cf-b0c3" name="Soulgreed" hidden="false">
+          <description>Each time a model is removed as a casualty as the result of an attack made by this weapon, the bearer immediately regains a Wound he lost earlier in the battle.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="2c6f-6e82-fd26-4c21" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Soulstealer" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Soulgreed"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="21a5-9eb3-eda1-39da" name="Tallyband" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="6de1-e1c4-d704-4631" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="4dd4-b09f-1651-4367" targetId="a30c-2d37-8e65-3993" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="f5ad-4244-4166-87d1" targetId="7e71-1691-295a-6121" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="b673-416a-83bf-8214" name="Units" minSelections="7" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="37db-ee39-11cb-2d18" targetId="044f-5642-ff01-477a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="be11-fd2b-d351-d717" targetId="741d-4dac-a6fb-a523" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="c7ea-1d4e-3b8b-5e3c" name="Distracting Swarm of Flies" hidden="false">
+          <description>Enemy units canont fire Overwatch against units from a Tallyband.</description>
+          <modifiers/>
+        </rule>
+        <rule id="08e6-f036-544f-c3b8" name="Enfeebling Nausea" hidden="false">
+          <description>At the start of each Assault phase, enemy units that are locked in combat with any units from a Tallyband must pass a Leadership test or reduce their Strength and Toughness characteristics by 1 for the duration of that phase.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="08b9-e369-64ce-c3b4" targetId="d5e2-6fc6-b3b6-c187" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="6f7a-93c2-621e-ca80" name="Tetragon of Darkness" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="9164-2c1c-aa2b-01d3" name="Bloodthirster" defaultEntryId="deac-0dc2-6ca6-0f90" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="cfcb-fa59-3681-e87c" targetId="5f84-effb-3544-c55f" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="deac-0dc2-6ca6-0f90" targetId="f4be-0336-9c09-01b0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="6441-4551-1c1b-20db" targetId="4f40-5660-e8fd-2fc2" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="8173-da73-b584-88a4" name="Bloodletters" defaultEntryId="44f2-6c3b-c2ff-e559" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="44f2-6c3b-c2ff-e559" targetId="2fc2-d3c6-a640-8672" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="59e9-86dd-6a26-9d9c" name="Lord of Change" defaultEntryId="fdec-9559-7b48-5c0d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="fdec-9559-7b48-5c0d" targetId="dac2-d0ef-2a14-4bb4" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="582c-8c7d-7b12-5f6c" name="Daemonettes" defaultEntryId="1abb-e926-d4c9-8ed6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1abb-e926-d4c9-8ed6" targetId="4238-f87d-1eec-8d86" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="9d1d-fef1-2e29-50fc" name="Pink Horrors" defaultEntryId="13ef-ba63-bbd8-49a2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="13ef-ba63-bbd8-49a2" targetId="a9cf-4334-0021-b8c1" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="3092-1e0f-3189-cd58" name="Great Unclean One" defaultEntryId="2710-c49f-4729-7663" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="2710-c49f-4729-7663" targetId="bb4d-dbfa-7136-7bdb" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="bad9-96a0-d4fa-cb74" name="Keeper of Secrets" defaultEntryId="0667-383c-cd03-7c8e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="0667-383c-cd03-7c8e" targetId="cf2e-c247-0a75-6303" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="9cba-e239-15e1-9f7e" name="Plaguebearers" defaultEntryId="32fc-7fee-9600-53d9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="32fc-7fee-9600-53d9" targetId="741d-4dac-a6fb-a523" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="0a9c-5fd0-a082-b53f" name="Dark Tetragon" hidden="false">
+          <description>As long as the Bloodthirster, Lord of Change, Great Unclean One and Keeper of secrets are alive, draw connecting lines to all four them and form the Tetragon of Darkness from the shape created from the joining lines. As long as the Tetragon is in effect, the following rules apply to all models.
+
+All friendly Daemon models re-roll their Invunerable save.
+All models inside the Tetragon gets shrouded.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="1844-1826-3675-2a90" name="The Blue Scribes" points="81.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="b2b4-937b-28dd-09a2" name="Spell Syphon" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="f19a-48d1-fcbb-06ec" name="Scoll of Sorcery" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="7fdf-fa19-e1e1-0406" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Blue Scribes" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jetbike (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="1fcc-694a-fa64-33d4" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="9be8-fd10-bd23-9b40" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2155-ac0f-8ebf-0a70" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="8243-b939-14a0-fcc8" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="cecc-a6c2-65b8-5f8c" name="The Changeling" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="d4a9-80b6-6246-ef33" name="Daemonic Psyker Level 1" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="35cd-8199-0beb-f616" name="Formless Horror" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="7637-94f1-04ce-4e1c" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Changeling" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="3c8a-4cd9-088c-37ff" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5685-0c97-31e1-fb1f" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="4eba-c06e-8118-4526" targetId="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="15a7-64ab-6901-4072" targetId="a567e325-4907-1e0f-0a93-b2e3f562a1f8" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e4e2-486b-79cc-451f" targetId="9b75f082-4d5c-8f8e-3c7d-a72b6d8d346a" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="8b01-9a11-8bb2-61bd" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="65e3-2ded-3ff6-cd8d" name="The Crimson Crown" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="fed7-d472-ae7b-8059" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Crimson Crown" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Add 1 to the Attacks characteristic of all models with the Daemon of Khorne special rule within 8&quot; of the bearer."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="6f54-3dec-116a-d38a" name="The Doomsday Bell" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="67a4-4961-12f8-2282" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Doomsday Bell" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Counts as Instrument of Chaos. Whilst bearer is on the field, all enemy units are at -1 Ld."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="920a-3489-676c-c34b" targetId="b9ac-931e-e950-bfe5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="2748-895f-9f49-dfef" name="The Endless Grimoire" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="2237-6543-849f-a09b" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Endless Grimoire" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="If your Warlord generates all his powers from the Discipline of Change, he knows all the its powers."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="eeb5-fded-337b-ae42" name="The Everstave" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="b2dc-9df3-9d3e-92a8" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Everstave" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Soul Blaze, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="b470-af0e-690a-83df" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Everstave Ranged" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Soul Blaze, Warpflame"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="5e9c-c5d4-c454-9e46" targetId="de070752-2c93-5c2c-d937-5cab4ff68531" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cc22-87ee-e120-e7b1" targetId="d938-b9d2-3b0b-df13" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="ea18-5586-602d-a2be" name="The Flaming Host of Tzeentch" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="b37b-0138-5b12-6b9f" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="91f8-5e1f-7440-6462" targetId="cecc-a6c2-65b8-5f8c" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="5dd3-7b5d-f7fb-8bd6" targetId="eeb8-23a2-fd50-af88" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="5004-e328-1ae5-04b2" name="Units" minSelections="9" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="ee5e-81b2-ed5b-1d21" targetId="7eeb-4507-a35b-c789" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="4c8e-e106-8064-9605" targetId="5c3a-0f55-df92-83e0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="3d43-ae89-dc2d-bfff" targetId="a9cf-4334-0021-b8c1" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="7d4c-94a3-a63e-a3b1" name="Mutagenic Flame" hidden="false">
+          <description>At the start of each turn, roll a D6 and consult the table as found in Warhammer 40,000 Apocalypse. The result applies until end of turn.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="89f7-4bf0-c3aa-e1d0" name="The Forbidden Gem" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="db1a-8b8d-84e2-8bb4" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Forbidden Gem" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the start of the Fight sub-phase, after any challenges have been issued and accepted but before any blows are struck, any model involved in a challenge with the bearer must roll 3D6 and subtract their Ld from the total. That model suffers a penalty to its WS an I equal to the result (to a minimum of 1) for the rest of the phase."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="c695-e2b9-0e86-cc18" name="The Great Promenade of Exquisite Excess" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="c050-d1c8-9325-83f7" name="The Masque of Slaanesh" defaultEntryId="a629-abec-e098-c02e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="a629-abec-e098-c02e" targetId="3e57-8b86-1e1f-e2fd" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="104c-9f4d-ddda-70e4" name="Units" minSelections="6" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1e6e-b52c-a5a8-58c1" targetId="4238-f87d-1eec-8d86" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="dbe6-474e-425a-2840" targetId="11ed-c0dd-7520-27e0" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="20cf-ce92-e1f3-981a" name="Grand Entrance" hidden="false">
+          <description>Units in this formation must start in strategic reserve and must deep-strike.Units in this formation may assault the turn they come in using this method.</description>
+          <modifiers/>
+        </rule>
+        <rule id="f456-298e-1548-7dc0" name="The Slaughter-dance" hidden="false">
+          <description>All critical strikes caused by rending from any of the models in this formation are resolved on a 4+ instead of a 6+</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="9cda-7277-c184-6ce6" name="The Hunter of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="837c-870c-be1f-2657" name="Karanak" defaultEntryId="d52f-0646-66bd-4f78" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="d52f-0646-66bd-4f78" targetId="7651-7d14-ae01-f5a5" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="9385-e312-79ca-71a0" name="The Impossible Robe" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="74f2-a38b-d013-0d43" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Impossible Robe" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="3+ Invulnerable Save. Each time wearer suffers an unsaved wound, it must pass a Leadership test or be removed from play. "/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="743e-8b4f-b3bf-9e9e" name="The Mark of Excess" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="71cf-dd67-b155-ba07" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Mark of Excess" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="At the end of a Fight sub-phase in which the bearer slays an enemy Monster or Character, add 1 to its A for the rest of the game."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="3e57-8b86-1e1f-e2fd" name="The Masque of Slaanesh" points="75.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="de10-757e-f945-3aa3" name="The Eternal Dance" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+        <rule id="7280-46e6-c138-9f6c" name="Unnatural Reflexes" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="32ab-57d7-a8d7-a01e" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Masque of Slaanesh" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="6"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="7"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="8"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="d700-1ba6-8d90-77b0" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="5f47-74e9-9405-cabb" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b527-d957-1cc3-4004" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e5a4-a750-08da-14bc" targetId="fb96ac11-4e7c-9523-2cc9-0a290975007f" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="2529-ce9d-8a19-c7b5" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="5df8-3d13-2131-21de" name="The Oracular Dais" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="0655-4ff6-9bf6-7a16" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Oracular Dais" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The Oracular Dais is a Disc of Tzeentch. At the start of each of your turns, you can choose one friendly unit with the Chaos Daemons faction that is in Reserve to automatically pass its Reserve Roll."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="bd52-2e0c-0ea5-59cb" name="The Slothful Claw" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="621c-5c13-ea75-e4ba" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Slothful Claw" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Rending, Specialist Weapon"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="0242-c589-fe18-213d" targetId="e002-c436-5f54-4f00" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="5ffd-5d75-39b6-42ee" targetId="105350a0-544c-d1a1-ca88-fb5a883415ce" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="a217-f06a-68b8-34b8" name="The Tallymen of Nurgle" points="0.0" categoryId="8dbf948c-125b-4886-b21e-3ccabc1e1188" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="09b9-12c0-ebab-90ac" name="Epidemius" defaultEntryId="fb2a-7a24-6504-9e1a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="fb2a-7a24-6504-9e1a" targetId="a30c-2d37-8e65-3993" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="e315-30b5-a77e-c502" name="Units" minSelections="7" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="1e44-edf1-e71d-7e20" targetId="741d-4dac-a6fb-a523" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="482c-f5ae-26f3-0983" targetId="69ff-0427-3a47-5b25" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="4c71-1db5-ec9e-62c7" name="Droning Cacophony" hidden="false">
+          <description>All units within 18&quot; of this formation must re-roll successful Leadership tests.</description>
+          <modifiers/>
+        </rule>
+        <rule id="1593-eb16-89cf-9a9c" name="A Thousand Deaths" hidden="false">
+          <description>(keeping track of each unsaved wound or Hull point on models with Mark of Nurgle/Daemon of Nurgle), you recieve a Strategic Victory point for every 70 Hull Points/Wounds.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="f1bdd112-9f6c-f677-4e98-892b33d6f16e" name="Unholy Might" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="aecfa2f9-daf5-72a4-fddb-d27f13270a73" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Unholy Might" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The model has +1 Strength on its profile."/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="ab06-4df6-b427-4e06" name="Warlord" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="e5a9-3830-8d2a-7cfc" name="Warp Storm Table" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="fbf6-6dc1-ed32-792a" targetId="f8658573-6aee-52ba-0d4e-be967a7472c6" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="6ece2600-dc3e-467f-8971-57f48ae89a58" name="Warp-forged Armour" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles>
+        <profile id="4b39df36-f664-e6b7-bde5-ae15c4c86d9c" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Warp-forged Armour" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="This grants an armour save of 3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="f457-2e18-4b93-4bcb" name="Warpflame Host" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="8cb5-d0b7-4e03-ff53" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="ca9e-50c0-1750-f92e" targetId="eeb8-23a2-fd50-af88" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="5f96-c1d9-acdb-4c04" targetId="cecc-a6c2-65b8-5f8c" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="4571-7fc0-c597-9080" name="Units" minSelections="9" maxSelections="9" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <links>
+            <link id="2db5-75a9-7b17-3c9c" targetId="a5d2-c03a-c9d8-8e2a" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="607c-0806-1ccb-04ee" targetId="5c3a-0f55-df92-83e0" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="cf53-9d64-a1c4-b086" targetId="a9cf-4334-0021-b8c1" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="b08e-fb2f-d73f-d894" name="Storm of Daemonic Fire" hidden="false">
+          <description>Add 1 to the Strength value of any Tzeentchian Flame Weapons (see Codex: Chaos Daemons) or psychic powers from the Discipline of Change unleashed by units from a Warpflame Host.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links>
+        <link id="22a7-728b-7b05-79bb" targetId="2a61-6373-1e4b-0211" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="6a4d5beb-257b-2e41-f56c-c50e256964cb" name="We are Legion" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="7cd59299-3cdc-ad47-3b54-55e8c96f6d40" name="We are Legion" hidden="false" page="0">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles/>
+      <links/>
+    </entry>
+    <entry id="65ea-60d1-b848-aa53" name="Whips of Agony" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="ec9d-c682-9966-1300" name="Agonising" hidden="false">
+          <description>The bearer of the Whips of Agony can re-roll all failed To Wound rolls with this weapon. Any model that suffers any unsaved Wounds from this weapon cannot make attacks for the rest of the Fight sub-phase.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="c1d3-12f7-2eec-8e02" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Whips of Agony" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Agonising"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links/>
+    </entry>
+    <entry id="4f40-5660-e8fd-2fc2" name="Wrath of Khorne Bloodthirster" points="300.0" categoryId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries>
+        <entry id="70d2-3253-5398-9055" name="Hellfire" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="5a16-f65b-d934-3fa5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Hellfire" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Soul Blaze"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="d494-4462-ddb2-fb00" name="Bloodflail" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="d9bd-366d-8839-a467" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Bloodflail (ranged)" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="7"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault D3"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+            <profile id="6f84-088e-969b-67c9" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Bloodflail (Melee)" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Specialist Weapon"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups>
+        <entryGroup id="026e-e09b-00ad-3658" name="Hellforged Artefacts of Khorne" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions>
+                <condition parentId="4f40-5660-e8fd-2fc2" childId="0aee-89a9-fc57-e48e" field="selections" type="equal to" value="1.0"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <links>
+            <link id="3f20-7d6e-2364-8537" targetId="65e3-2ded-3ff6-cd8d" linkType="entry">
+              <modifiers/>
+            </link>
+            <link id="3233-77dc-4310-01d3" targetId="8609-0eaa-6027-8e0c" linkType="entry">
+              <modifiers/>
+            </link>
+          </links>
+        </entryGroup>
+        <entryGroup id="4047-5b87-e38a-8933" name="Weapon" defaultEntryId="224b-3a8e-0376-934c" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="224b-3a8e-0376-934c" name="Axe of Khorne" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="b0ac-5496-23b5-2c60" targetId="596ac2cf-087d-e484-c8f1-506793046ef5" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups>
+            <entryGroup id="0aee-89a9-fc57-e48e" name="Hellforged Artefacts" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+              <entries/>
+              <entryGroups/>
+              <modifiers>
+                <modifier type="set" field="maxSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                  <conditions>
+                    <condition parentId="4f40-5660-e8fd-2fc2" childId="026e-e09b-00ad-3658" field="selections" type="equal to" value="1.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <links>
+                <link id="aade-ea20-f52c-b18b" targetId="69c6-5dab-8b48-383e" linkType="entry">
+                  <modifiers/>
+                </link>
+                <link id="5aeb-2afc-6fd8-11bb" targetId="5c8a-f784-1e04-6a67" linkType="entry">
+                  <modifiers/>
+                </link>
+              </links>
+            </entryGroup>
+          </entryGroups>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules>
+        <rule id="8a19-6899-5032-d3e0" name="Hatred (Characters)" hidden="false">
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="2575-3b5d-1399-fb66" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Wrath of Khorne Bloodthirster" hidden="false" page="0">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Flying Monsterous Creature (Character)"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="10"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="9"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="ab02-8f9f-7985-888d" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="b0ee-4195-879d-c5ef" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="fffd-e032-8470-3cd2" targetId="f18931f3-81ef-799f-eaa3-07c0067183b9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="de22-101c-f8e4-4dd6" targetId="274da1cc-d0f3-8e8c-4ded-3d27931a934e" linkType="profile">
+          <modifiers/>
+        </link>
+        <link id="eed8-d872-5acc-8bd9" targetId="685156ec-d040-61a1-65e7-cf5ba676de3f" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1049-0261-f79e-79e1" targetId="ab06-4df6-b427-4e06" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e9f4-90d1-fa40-bd8b" targetId="3e48-4a3f-a971-0f19" linkType="entry group">
+          <modifiers>
+            <modifier type="set" field="maxPoints" value="50.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="1cf0-a94d-c6df-f10f" targetId="d7f7-7923-faeb-8dc5" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="8128-60c8-7afc-e9db" name="Zarakynel" points="666.0" categoryId="c888f08a-6cea-4a01-8126-d374a9231554" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="186c-9f16-2620-7904" name="The Souleater Sword" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules>
+            <rule id="800f-65a8-388b-c648" name="Souleater" hidden="false">
+              <description>At the end of any fight sub-phase where this weapon has inflicted an unsaved wound, roll a D6. on a 2+, the bearer gains an additional wound (up to a max of 10).</description>
+              <modifiers/>
+            </rule>
+          </rules>
+          <profiles>
+            <profile id="d071-2e7e-35e1-464b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="The Souleater Sword" hidden="false">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="1"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Meele, Souleater, Specialist Weapon"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <rules>
+        <rule id="f59a-562f-8a8a-1b79" name="Angel of Despair" hidden="false">
+          <description>It re-rolls all failed To-hit and To-wound rolls in combat and is equipped with assault grenades when charging. When charging into an assault, it gets +D3 attacks. 
+Any non-Fearless unit in CC with this unit must pass a leadership check or be unable to strike blows that turn. Roll once for the unit, with IC&apos;s rolled separately.</description>
+          <modifiers/>
+        </rule>
+      </rules>
+      <profiles>
+        <profile id="ac37-7704-ae1d-e0cb" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Zarakynel - Daemon Lord of Slaanesh" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Gargantuan Creature"/>
+            <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+            <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+            <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+            <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="7"/>
+            <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+            <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="10"/>
+            <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+            <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+            <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-/3++"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+        <profile id="0730-3bf6-5cec-2b98" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Deathly Rapture" hidden="false">
+          <characteristics>
+            <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+            <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+            <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+            <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault D6, Pinning"/>
+          </characteristics>
+          <modifiers/>
+        </profile>
+      </profiles>
+      <links>
+        <link id="4bb3-e072-8b18-0472" targetId="0c1bfed3-f6ff-c810-fa80-9494794a1bdd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="f944-cc17-8762-46e8" targetId="4f9feb72-fede-03da-69d8-6efe86756bc3" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="14e4-091b-56e5-41fa" targetId="521fb0b8-870d-f3e9-6f25-483767d3b77e" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="dd6c-57e5-f350-e8bb" targetId="380b621e-1fc4-dcf6-8fb6-894151bcd548" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+  </sharedEntries>
+  <sharedEntryGroups>
+    <entryGroup id="beefcd38-5e93-0f5e-0b6e-9843ecc07bd1" name="Daemonic Psyker Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="ac0af1b3-1f96-af3b-e56f-fccb075e59ff" name="Psyker Level 1" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+        <entry id="77cde8cf-c2cd-8214-4823-0c873282aa02" name="Psyker Level 2" points="50.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+        <entry id="0e0967c7-52d9-e771-95ba-9479ebfac759" name="Psyker Level 3" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles/>
+          <links/>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <links/>
+    </entryGroup>
+    <entryGroup id="3e48-4a3f-a971-0f19" name="Daemonic Rewards" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="5653-a887-d8b0-e33a" name="Greater Rewards" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="141c-8671-f869-1237" name="D6 Greater Daemonic Reward" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="5e25-0c4e-760f-fa43" name="Lesser Rewards" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="ae04-4461-9af9-5f49" name="D6 Lesser Daemonic Reward" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+        <entryGroup id="819f-1fa3-f31c-ddb5" name="Exalted Rewards" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="094c-e680-9fbe-98fa" name="D6 Exalted Daemonic Reward" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links/>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <links/>
+    </entryGroup>
+    <entryGroup id="d628-f2bf-5d9e-bb65" name="Hellforged Artefacts of Khorne" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <links>
+        <link id="caa6-7e6b-8555-8d8c" targetId="210c-b684-6cd6-7bc3" linkType="entry">
+          <modifiers>
+            <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition parentId="direct parent" childId="5f84-effb-3544-c55f" field="selections" type="instance of" value="0.0"/>
+                    <condition parentId="direct parent" childId="f4be-0336-9c09-01b0" field="selections" type="instance of" value="0.0"/>
+                    <condition parentId="direct parent" childId="4f40-5660-e8fd-2fc2" field="selections" type="instance of" value="0.0"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </link>
+        <link id="6e39-0d08-d930-352a" targetId="69c6-5dab-8b48-383e" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="069e-985a-d94d-9dc6" targetId="65e3-2ded-3ff6-cd8d" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="33fb-cb40-27dc-95ba" targetId="5c8a-f784-1e04-6a67" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4055-d1b8-afbc-23e7" targetId="8609-0eaa-6027-8e0c" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="dc70-3046-b972-d405" targetId="72cd-767c-468a-ed69" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entryGroup>
+    <entryGroup id="1fb8-50d5-aa82-7d53" name="Hellforged Artefacts of Nurgle" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries>
+        <entry id="e7c7-0ab1-7569-d36c" name="The Doomsday Bell" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="28">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="450b-db1c-e6d0-d60c" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="The Doomsday Bell" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The Doomsday Bell is an Instrument of Chaos. Whilst the bearer is on the battlefield, subtract 1 from the Leadership characteristic of all enemy units."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="5774-b567-8a9b-7a3f" name="Grotti the Nurgling" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="28">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="307e-6535-6392-3ca3" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Grotti the Nurgling" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Reduce the Toughness characteristic of all models (friend or foe) by 1 whilst they remain within 6&quot; of a model accompanied by Grotti the Nurgling, unless they have lh e Daemon of Nurgle special rule."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="53ee-0761-fe3c-ee9a" name="Horn of Nurgle&apos;s Rot" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="28">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="f84d-0d14-359d-1c53" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Horn of Nurgle&apos;s Rot" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Afler resolving the bearer&apos;s close combat attacks, add 1 model lo a friendly unit of Plaguebearers of Nurgle within 12&quot; of the bearer for each enemy model that was slain.
+The model musl be placed within unit coherency, more than 1&quot; from any enemy models. Any models that cannot be placed in this manner are lost."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="8f2f-3370-b3e1-136a" name="Death&apos;s Head of Duke Olaks" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="f3c0-122a-1db6-70ca" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Death&apos;s Head of Duke Olaks" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="1"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1, Large Blast, One Use Only, Poisoned (2+)."/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links/>
+        </entry>
+        <entry id="7afe-ab9e-1ab7-a155" name="Epidemia" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="28">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="0d0d-2283-4317-8a76" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Epidemia" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="+1"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Mass Contagion, Specialist Weapon"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="f5f7-2909-6260-7e65" targetId="164e-9886-20f7-ee7d" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+        <entry id="6d6d-1949-866d-a2a9" name="Corruption" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Scions of the Warp" page="28">
+          <entries/>
+          <entryGroups/>
+          <modifiers/>
+          <rules/>
+          <profiles>
+            <profile id="c7c3-2a9b-b52b-1a4e" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Corruption" hidden="false" book="Scions of the Warp" page="28">
+              <characteristics>
+                <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+                <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="*"/>
+                <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+                <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Hyper-infection, Touch of Rust"/>
+              </characteristics>
+              <modifiers/>
+            </profile>
+          </profiles>
+          <links>
+            <link id="96cf-4d0b-6941-e7bd" targetId="dd3b7105-d7b0-42cc-a648-94930c817ae7" linkType="rule">
+              <modifiers/>
+            </link>
+            <link id="9edf-976b-0084-0de9" targetId="c63d-0442-8b83-e6eb" linkType="rule">
+              <modifiers/>
+            </link>
+          </links>
+        </entry>
+      </entries>
+      <entryGroups/>
+      <modifiers/>
+      <links/>
+    </entryGroup>
+    <entryGroup id="71ea-0490-8ee7-c722" name="Hellforged Artefacts of Slaanesh" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <links>
+        <link id="5dce-c247-aa27-9038" targetId="1407-a19d-0d8a-eabd" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1e3b-2a61-c365-aec5" targetId="1f57-87d5-c469-07e4" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="ca34-c590-9fd1-be80" targetId="bd52-2e0c-0ea5-59cb" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="47aa-e9a1-252f-1703" targetId="89f7-4bf0-c3aa-e1d0" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4344-b9f4-6516-3720" targetId="65ea-60d1-b848-aa53" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="f8ee-efd4-4a73-0cc8" targetId="743e-8b4f-b3bf-9e9e" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entryGroup>
+    <entryGroup id="6a22-750e-232d-a582" name="Hellforged Artefacts of Tzeentch" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <links>
+        <link id="ba91-940e-1e3f-c96d" targetId="4a04-a0cf-79ff-494d" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="1518-ad2e-915c-26af" targetId="9385-e312-79ca-71a0" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="c03d-42f9-ebe5-4ba9" targetId="61ed-0386-f1a4-8cd9" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="4691-0e78-8dca-9238" targetId="2748-895f-9f49-dfef" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="bb56-42ae-c09f-bb3a" targetId="eeb5-fded-337b-ae42" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entryGroup>
+  </sharedEntryGroups>
+  <sharedRules>
+    <rule id="aa6d7d3a-ce11-ed0b-eb26-d6b474143773" name="Acute Senses" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="d7f7-7923-faeb-8dc5" name="Adamantium Will" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="28b402a9-3d5b-6641-7998-036ac0214ec6" name="Armourbane" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="add2bfb1-23e3-51d0-287b-1e4a6d4f4f19" name="Aura of Change" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="2cc57d46-37f2-f4bb-b7a2-ecfe2f839ca4" name="Bellow of Endless Fury" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="5cb054a3-97b5-4578-dd3e-f69e2ef5b170" name="Bloodletter Crew" hidden="false" book="Errata Oct 22nd 2014">
+      <description>This mode makes 2 additional Str 4 AP3 attacks at WS 5 each assault phase. These are done Initiative step 4 (does not grant an extra pile in). On a successful charge, the strength is increased to 5.</description>
+      <modifiers/>
+    </rule>
+    <rule id="29d5b769-200d-1d40-5de9-9cc49983cd41" name="Blue Horrors" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="ca5ce6c3-c53f-bcd2-b9ec-c35e5680ad35" name="Brotherhood of Sorcerers" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="46a8dc0a-f078-1d1c-236a-d1115b97c387" name="Bulky" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="057845e6-6ec3-8899-62b9-1576ba1891fc" name="Change Discipline" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="cb53-fc30-9e5c-3240" name="Colossal" hidden="false">
+      <description>A model with this rule piles in and fights at Initiative 1.</description>
+      <modifiers/>
+    </rule>
+    <rule id="c64d-15e2-1e7f-9681" name="Concussive" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="8e5a7f23-8f7c-246b-71d9-c52e268c2e06" name="Daemon" hidden="false">
+      <description>5+ Invunerable Save and causes fear.</description>
+      <modifiers/>
+    </rule>
+    <rule id="4f9feb72-fede-03da-69d8-6efe86756bc3" name="Daemon Lord" hidden="false">
+      <description>The invunerable save is 3+</description>
+      <modifiers/>
+    </rule>
+    <rule id="ece4-bc8c-add4-6f6a" name="Daemonic Corruption" hidden="false">
+      <description>Objective Markers controlled by units from this Detachment count as controlled for the rest of the game, even if the controlling player has no units wihtin 3&quot; of them. This effect lasts until an enemy scoring unit cleanses the objective by controlling it.</description>
+      <modifiers/>
+    </rule>
+    <rule id="521fb0b8-870d-f3e9-6f25-483767d3b77e" name="Daemonic Instability" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="87adee1e-acae-74dc-0663-046470e4c144" name="Daemonic Resilience" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="28e85a6b-69ef-5afb-7c92-32decbc0dc0a" name="Decapitating Blow" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="380b621e-1fc4-dcf6-8fb6-894151bcd548" name="Deep Strike" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="dfc1a725-4312-12be-dfdb-67660992857c" name="Disruptive Song" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="85a1-6c7f-aa19-be65" name="Dreadskulls" hidden="false" page="0">
+      <description>Place a marker next to each unit that takes one or more hits from this attack. Friendly Daemon units that charge a unit so marked do not suffer an Initiative penalty if charging through difficult terrain. Remove any Dreadskulls markers at the end of the Assault phase. </description>
+      <modifiers/>
+    </rule>
+    <rule id="aa11-a814-7133-fb3f" name="Escalating Bloodlust" hidden="false">
+      <description>Units from a Murderhorde add 1 to their Attacks in close combat whilst they are within 6&quot; of any other unit from their Formation.</description>
+      <modifiers/>
+    </rule>
+    <rule id="f0572e80-c3a6-3df8-f98d-2e5a8f74c149" name="Exalted Locus of Beguilement" hidden="false" page="0">
+      <description>Re-roll failed To Hit rolls in close combat. Enemies cannot refuse challenges.</description>
+      <modifiers/>
+    </rule>
+    <rule id="d22adfca-34c9-d6ca-034b-c5e21dc08d46" name="Exalted Locus of Conjuration" hidden="false" page="0">
+      <description>To Hit rolls of 6 get extra S4 AP- Poisoned (4+) hit.</description>
+      <modifiers/>
+    </rule>
+    <rule id="f8950615-4df3-152e-9f8f-6308a078b6a5" name="Exalted Locus of Contagion" hidden="false" page="0">
+      <description>+1 S for psychic powers.</description>
+      <modifiers/>
+    </rule>
+    <rule id="447c353f-26f0-87cb-1ee9-8aacf4ca6311" name="Exalted Locus of Wrath" hidden="false" page="0">
+      <description>Hatred</description>
+      <modifiers/>
+    </rule>
+    <rule id="63673c55-151e-2440-c5e7-273a93b61648" name="Exalted Rewards" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="5c742f7d-fd81-ee06-4793-5f99e25f4aab" name="Excess Discipline" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="179e20b2-b985-74fe-b514-8f6da2e8dea3" name="Fear" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="ded5-cb2d-42be-cabf" name="Fearless" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="bc27e394-d6c3-024b-4eab-144dd9379571" name="Feel No Pain" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="fe811e51-1fd9-bf8b-c9b5-cdca0a54cdd3" name="Fleet" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="c0ffb4b1-a5e3-f56f-c2b2-2f3bfa2fcb54" name="Fleshshredder" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="9a4fd561-d31a-c6a3-01d6-44c544f51df7" name="Furious Charge" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="18f7a4e9-db49-40a2-4cd9-45c37538a3eb" name="Gorefeast" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="7234cfd3-7878-6c3c-4d8c-bb4ba71fbd98" name="Greater Locus of Change" hidden="false" page="0">
+      <description>Each turn, the unit has Strength D6.</description>
+      <modifiers/>
+    </rule>
+    <rule id="8451920b-8b38-134a-3b16-7c65e7c26429" name="Greater Locus of Fecundity" hidden="false" page="0">
+      <description>Feel No Pain</description>
+      <modifiers/>
+    </rule>
+    <rule id="95e8f813-4b22-1f94-f566-0dcc3bcf6bfa" name="Greater Locus of Fury" hidden="false" page="0">
+      <description>Rage.</description>
+      <modifiers/>
+    </rule>
+    <rule id="390061fa-2828-9c86-a55e-8cf1ab4b7c3f" name="Greater Locus of Swiftness" hidden="false" page="0">
+      <description>+5 Initiative.</description>
+      <modifiers/>
+    </rule>
+    <rule id="c5d58cf9-4a96-1325-27fd-a0a6cee6d73b" name="Greater Magic Weapons" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="538ab613-3704-07d2-1af2-7b5514a5517f" name="Greater Rewards" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="2815-f85c-fa92-9679" name="Harbinger of Khorne" hidden="false" page="66">
+      <description>If the Herald of Khorne from this Formation is a Lesser Locus of Abjuration, Greater Focus of Fury, or an Exalted Locus of Wrath, the special rules associated with that locus affect all units from this Formation within 12&quot; of him. If such a unit is also affected by another locus, they will receive both benefits. </description>
+      <modifiers/>
+    </rule>
+    <rule id="d5e2-6fc6-b3b6-c187" name="Harbinger of Nurgle" hidden="false">
+      <description>If the Herald of Nurgle from this Formation is a Lesser Locus of Virulence, Greater Locus of Fecundity, or an Exalted Locus of Contagion, the special rules associated with that locus affect all units from this Formation within 12&quot; of him. If such a unit is also affected by another locus, they will receive both benefits. </description>
+      <modifiers/>
+    </rule>
+    <rule id="df05-1da8-c69d-c24c" name="Harbinger of Slaanesh" hidden="false">
+      <description>If the Herald of Slaanesh from this Formation is a Lesser Locus of Grace, Greater Locus of Swiftness, or an Exalted Locus of Beguilement, the special rules associated with that locus affect all units from this Formation within 12&quot; of him. If such a unit is also affected by another locus, they will receive both benefits. </description>
+      <modifiers/>
+    </rule>
+    <rule id="2a61-6373-1e4b-0211" name="Harbinger of Tzeentch" hidden="false">
+      <description>If the Herald of Tzeentch from this Formation is a Lesser Locus of Transmogrification, Greater Locus of Change, or an Exalted Locus of Conjuration, the special rules associated with that locus affect all units from this Formation that are within 12&quot; of him. If such a unit is also affected by another locus, they will receive both benefits. </description>
+      <modifiers/>
+    </rule>
+    <rule id="24b5d0f6-4d76-38fb-46a5-15af6e009f4b" name="Hatred" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="201cf166-0bdd-0a6c-29c5-5d7c823e723e" name="Hellforged Artefacts" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="fb96ac11-4e7c-9523-2cc9-0a290975007f" name="Hit &amp; Run" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="42eb7a96-2072-b9bc-7700-f6b8f5e41564" name="Icon of Chaos" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="1247f6ba-019e-08da-d8f0-8cba8a1b6aec" name="Independent Character" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="bcf33bb7-143c-199f-0e4a-b75b8abb71c6" name="Infiltrate" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="7b1b6029-4405-bdd2-fb61-aca546e8e72a" name="Instant Death" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="b9ac-931e-e950-bfe5" name="Instrument of Chaos" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="91b96d0d-5c8e-05d6-66f5-853a0e2cef6b" name="It Will Not Die" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="1009d9ed-1c9b-bc21-4ca6-f514fa3af669" name="Lamprey&apos;s Bite" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="fbb667d5-8f46-f433-9656-f173a7abc283" name="Lesser Locus of Abjuration" hidden="false" page="0">
+      <description>Adamantium Will.</description>
+      <modifiers/>
+    </rule>
+    <rule id="53e054c0-d3ed-590a-5d77-db1cf45742ce" name="Lesser Locus of Grace" hidden="false" page="0">
+      <description>Move Through Cover.</description>
+      <modifiers/>
+    </rule>
+    <rule id="7fc4dafe-ecea-a8d2-8dc7-7cd1b58b6351" name="Lesser Locus of Transmogrification" hidden="false" page="0">
+      <description>Place D3 Blue Horror counters rather than 1.</description>
+      <modifiers/>
+    </rule>
+    <rule id="e8614f30-7c26-21f0-74c0-ea5b73c18bb3" name="Lesser Locus of Virulence" hidden="false" page="0">
+      <description>To Hit rolls of 6 are Poisoned (2+).</description>
+      <modifiers/>
+    </rule>
+    <rule id="abf4c9f1-a16b-a62e-33f3-9e571b95c5fe" name="Lesser Rewards" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="0026fb8e-53f6-ba79-ccfe-d4f67bbf7b9c" name="Lord of Blood" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="4db62daf-117a-2864-1144-f39ea2f605c2" name="Magic Made Manifest" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="f14de5d7-6371-3f85-c30a-c82bd5cf264c" name="Magic Weapons" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="98304f1b-c1b0-f157-ca35-8d5a633cebbd" name="Move Through Cover" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="6aa74621-89d6-7289-f0c3-a12bb454e912" name="Nurgling Infestation" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="d48ac220-a057-199d-7d2a-981c094216eb" name="Oracle of Eternity" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="207c581a-edbb-e35f-ddb8-b4442e0b1184" name="Outflank" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="8d6f4c07-9f52-8cd7-4b85-72716d063bf4" name="Plague Discipline" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="6ac2f44f-d25b-8ea5-d36a-5f2267ad7613" name="Poisoned (4+)" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="843b0787-9074-2cd1-3aa1-d963f9ea4d51" name="Preffered Enemy (Eldar &amp; Dark Eldar)" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="e06ec47b-ac59-1fe9-5e5e-8bc9af5ff0df" name="Prey of the Blood God" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="41b0-7f97-46cb-d026" name="Rage" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="457d2aeb-5024-e443-db5e-8f81b7d231b0" name="Rage Embodied" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="105350a0-544c-d1a1-ca88-fb5a883415ce" name="Rending" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="cea2f531-e1ab-7405-dac8-18c7d58fc61a" name="Riftbringer" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="6cf163f7-da38-2d67-9b2b-dba71fcbfa6a" name="Scout" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="4aee02f6-2a24-9888-98d5-a94b7b7f371b" name="Shrouded" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="28a8-aef7-82fa-61d1" name="Skullrain Salvo" hidden="false">
+      <description>All of the Skull Cannons in a Gorethunder Battery must be fielded as a single vehicle squadron. Whilst this Formation includes three Skull Cannons that can fire, the squadron can fire a single Skullrain Salvo instead of firing normally. To do so, nominate one model in the squadron as the firer and use the Skullrain Salvo profile.</description>
+      <modifiers/>
+    </rule>
+    <rule id="b2739f3a-ade3-aa30-1556-db484ddffbf3" name="Skulls for the Skull Throne!" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="4aaf30a3-4dc7-1f26-3cf6-b0887870bbd9" name="Slashing Attack" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="ece8645d-de4f-c7a6-1031-2ea5d25d807f" name="Slime Trail" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="05846d0f-c133-80db-c36e-8af301cf4bec" name="Slow &amp; Purposeful" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="e3c5b8e4-c498-8b45-8ca0-7ed4926593af" name="Soporific Musk" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="d938-b9d2-3b0b-df13" name="Soul Blaze" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="5bba22ed-99ed-1e83-0226-76fcfac840e1" name="Souleater" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="981a0462-d81e-8e26-a50e-c9784942f952" name="Soulscent" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="e002-c436-5f54-4f00" name="Specialist Weapon" hidden="false">
+      <modifiers/>
+    </rule>
+    <rule id="e608a13f-b00d-0672-5d6a-8b6c7a72f4f8" name="Swarm" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="7655d6a3-a37d-e989-7e1a-d9ab8c69e711" name="Swarms" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="cdc4f396-3f0d-27ef-3a35-66e353ce32db" name="The Eternal Dance" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="32c07aa9-f433-5440-2e5c-02531d9d645c" name="The Tally of Pestilence" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="3b36-3a86-4f92-9014" name="The Warp Unleashed" hidden="false">
+      <description>You can choose to re-roll any Daemonic Instability tests for units from this Detachment.</description>
+      <modifiers/>
+    </rule>
+    <rule id="d0ca56e6-0fc6-1592-3364-7e44a1e6425f" name="Totem of Endless Bloodletting" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="dd3b7105-d7b0-42cc-a648-94930c817ae7" name="Touch of Rust" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="24d39af8-f701-b60a-33b5-1408539e0d95" name="Tzeentch Psyker Powers" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="bcd8-e98a-ec36-2deb" name="Unearthly Power" hidden="false">
+      <description>When rolling on the Warp Storm table you can choose to add or subtract 1 from the result.</description>
+      <modifiers/>
+    </rule>
+    <rule id="55cd71e1-7772-3e2c-6ccd-d6274008f370" name="Very Bulky" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="f8658573-6aee-52ba-0d4e-be967a7472c6" name="Warp Storm table" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="2b869785-f82a-a861-2fd5-c16be9390dd7" name="Warp Tether" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="de070752-2c93-5c2c-d937-5cab4ff68531" name="Warpflame" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="aa8381a2-dde2-5acf-ae70-353f9fefe05e" name="Watch this!" hidden="false" page="0">
+      <modifiers/>
+    </rule>
+    <rule id="c63d-0442-8b83-e6eb" name="Hyper-infection" hidden="false" page="28">
+      <description>Any hits inflicted by this weapon automatically cause Wounds (there is no need to roll).  Use the bearer&apos;s Strength characteristic as normal for the purposes of armour penetration against vehicles or determining if a target suffers Instant Death.</description>
+      <modifiers/>
+    </rule>
+    <rule id="164e-9886-20f7-ee7d" name="Mass Contagion" hidden="false" page="28">
+      <description>Each time a model is removed as the result of an attack made by this weapon, its unit must
+immediately pass a Toughness test or suffer an additional Wound with no armour or cover saves allowed.</description>
+      <modifiers/>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="596ac2cf-087d-e484-c8f1-506793046ef5" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Axe of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Decapitating Blow, Specialist Weapon"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="8375119f-55e4-7cf7-70ef-36ae7da87f7e" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Banner of Blood" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Once oer game, the unit charges 6+D6&quot;."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f756a086-e42b-7741-83e2-2ea37e828462" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Beast of Nurgle" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beast"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="D6+1"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="7"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="13f0ca19-2aff-e3bb-e536-2be1b57f6bf2" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Bellow of Endless Fury" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="1b5f95f3-b556-15b4-3752-1cbfdcdb1be7" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Blasted Standard" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Once per game, when the unit shoots or attempts to manifest a Witchfire power, any target hit by that attack takes an additional 2D6, Strength 4, AP- hits."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="b427-0e8c-69df-0aba" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Blood Throne of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="12"/>
+        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="12"/>
+        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP" value="3"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Chariot, Open-Topped"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="66e0730b-0c5b-a96d-df77-c6395c39f504" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodcrusher of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="414214a7-5bc0-e376-0869-4a7140a11b67" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodletters of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="e38600d3-cc9f-2086-47a1-f954f11bb8cd" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Bloodthirster" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="7"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="7"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="8701-9490-8c77-dfcf" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Blue Fire of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="18&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="9"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy D3, Warpflame"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="40dee735-1697-19c9-4d5e-562028de6a1c" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Breath of Chaos" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Breath of Chaos is a Template weapon.  Any models fully or partially under the template suffer one wound on a D6 roll of 4+, with no armor saves allowed!  Vehicles touched by the template suffer a glancing hit on a D6 roll of 4+."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="925fc93b-51ed-95bb-4d26-e27055d1857f" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Collar of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="A unit containing one or more models with a Collar of Khorne has a +2 bonus to all Deny the Witch rolls."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="4b78d1b7-ae2b-f81c-630a-cb15b3e5f09d" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemon Prince of Chaos" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="cb0abe53-7181-8c2d-10c4-6b7a6973cbed" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Daemonettes of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="4d8e5394-868b-2ff6-2578-bc1b1a908f02" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Daemonic Flight" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Monstrous Creatures with this Gift are Flying Monstrous Creatures.  Other models with this Gift add Jump to their Unit Type."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="8cfe-19e9-8e41-ce7c" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Dreadnought CCW" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="x2"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="d462047a-af72-5310-6608-e90900955a4c" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Epidimius" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="93846a65-3434-5af7-c12e-4861597343f6" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Exalted Alluress" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="2f0dc34c-26fa-f045-40b1-cb370e4fd09d" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Exalted Seeker Chariot of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="20f50052-d3a9-9113-3b9d-315b378317e2" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Fateweaver, The Oracle of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="9"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="23203b9b-d587-d462-5801-b8231511455a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Fiends of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beasts"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="99c02023-984b-bc84-579b-01f6075ffc45" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Flamers of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump, Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="c7fec7c8-6bd6-2b91-f782-1f0310d57597" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Flesh Hounds of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beasts"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f8734fb0-9ddd-afa8-7e9f-a0a3a13f2fea" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Furies of Chaos" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump, Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="fc19-5b2f-9692-efac" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Great Axe of Khorne" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="D"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="AP2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Collossal"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="e2a1f5a1-d77b-fd7f-642b-48d426e7f4ba" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Great Unclean One" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="5"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="344ceff3-6606-5156-1c1b-bec57f5d610b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Harvester" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="5"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 6"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="2f692f01-8637-a8c7-de2c-23060a63958b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Hellblade" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="40f525f4-9d88-7b4d-15ed-044bd2e4aaf7" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Hellflayer Chariot of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="56cd0e77-4032-9070-7826-91b5101bc620" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="56d2f3a3-f2d8-1ef0-5c79-fde39c7a09b9" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Nurgle" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="2ab19c32-7eae-0f27-ce45-63733cc78894" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="7"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="955c5161-a34e-aead-f474-424a7a766209" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Herald of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="2"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="4863a05f-0308-b162-a9b1-26f41a46326f" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Instrument of Chaos" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="If the Daemon bearing this Gift is involved in a fight which results in a draw, its side counts as having won by one wound.  If both side include an Instrument of Chaos, the result remians a draw."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="6a321da9-2a17-9f61-bcd0-5c1ebc7e2776" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Iron Hide" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Models with Iron Hide receive a 3+ Armor Save."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="9a6dfce0-272e-21b7-ee5f-8e922de3b3da" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Karanak, Hound of Vengence" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Beasts"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="5"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f4df6f3c-2bd7-c284-5884-7cda57f47d4c" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Keeper of Secrets" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="8"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="10"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="af0a2bf8-f618-6203-02b5-41752847fa4f" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Ku&apos;gath, The Plaguefather" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="6"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="6"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="5"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="b4b482b2-93bd-ba5a-dca6-212fb94c2445" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Lash of Khorne" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="12&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="b6bc877d-daff-8c0e-a4aa-a0e559968b45" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Lord of Change" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="5"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="be186128-7311-329e-360c-0e994696ac2b" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Mawcannon" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="6"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 1"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="ca1f1665-26f8-78ac-865a-b6d81019e51c" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Necrotic Missles" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="24&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="N/A (Poison 4+)"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="2"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Ordnance 1, Large Blast"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="4a34016f-a204-89c7-0032-c1bf57cf808a" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Noxious Touch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="The Daemon&apos;s Close Combat Attacks are Poisoned, wounding on a 2+ as described in the Core Rulebook"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="9c710ae0-b1f5-69b2-99c6-fa88f6567436" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Nurglings" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="3"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="ac4e-94da-4bb7-7c2f" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Pink Fire of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="Template"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="5"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Torrent, Warpflame"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="ca4c2101-0e5f-9eb4-544d-812c3204537d" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Pink Horrors of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="f5002729-935e-853f-0071-9a65b1d163ea" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Plague Banner" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Once per game, for one Fight sub-phase, the unit&apos;s melee weapons have Poisoned (2+)."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="3d54ee45-5812-7b77-ace1-ecfc38732868" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Plaguebearers of Nurgle" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="5"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="2"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="e20bdf1a-af78-1737-876b-d951aa7ad3eb" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Plaguesword" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="-"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="User"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="-"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Melee, Poisoned (4+), Touch of Rust"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="647ad98c-97ba-d938-ac9e-baf3f84f7f26" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Pyrocaster" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump, Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="0e35d665-ef26-d0db-1ab8-bfbbc044a347" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Rapturous Standard" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="Once per game, for one Fight sub-phase, all models locked in combat with the unit have -D3 WS.  Daemons of Slaanesh/Mark of Slaanesh are immune."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="1d20bb40-3a12-838a-c9cb-2b2c50eebf2e" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Screamers of Tzeentch" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jetbikes"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="-"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="dcd46905-80af-46c5-b6ab-d3dfd67313ce" profileTypeId="725a358c-765b-498c-8de5-399fc0c0725f" name="Seeker Chariot of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="11"/>
+        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="11"/>
+        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="10"/>
+        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Transport, Chariot, Fast, Open-Topped"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="8dea4b8a-0d98-6190-3bef-13ad6669e85a" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Seekers of Slaanesh" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Cavalry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="4"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="6"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="cd12c982-ebe3-a6e3-7de3-70bfa3a3dc51" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Skarbarand, The Exiled One" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Monstrous Creature"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="10"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="0"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="8"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="6"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="4"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="6"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="2141-b904-3142-747d" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Skullrain Salvo" hidden="false">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="36&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="8"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="3"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Heavy 1, Dreadskulls, Ignores Cover, Apocalyptic Blast"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="358b1d34-c3e7-362f-4749-4e6b9aacb8c3" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Skulltaker" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="7"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="4"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="4"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="5"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="5+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="1a86e3c0-b341-5402-69c2-6df032c0146a" profileTypeId="3dadd2ff-33f1-41dd-85c7-bee5a7dfa413" name="Soul Grinder of Chaos" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="3"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="6"/>
+        <characteristic characteristicId="8cdd4fef-d1ba-4007-992c-b6f93e86d43f" name="Front" value="13"/>
+        <characteristic characteristicId="5f9a3780-eecb-4c70-be1d-e5bd06b06e9e" name="Side" value="13"/>
+        <characteristic characteristicId="0a9f33cb-0412-420a-89d2-20707c360bd2" name="Rear" value="11"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="ae95a1af-719f-4365-b951-33cd3ca9148a" name="HP"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="836652c6-e65b-a27a-d50f-3fd7858223df" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Blue Scribes" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Jump, Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="4"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="3"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="1c8cca6b-9579-ecf0-81d0-87212598e0e5" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Changeling" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="2"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="3"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="1"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="3"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="1"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="4+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="b72d7741-1d83-1cf7-0c47-fe9c794871d3" profileTypeId="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="The Masque" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="c2b4b061-a0fd-499d-8a3d-6ee52587cbd5" name="Unit Type" value="Infantry, Char"/>
+        <characteristic characteristicId="5ee4ff0b-b244-4670-9d05-91d10f80c32e" name="WS" value="5"/>
+        <characteristic characteristicId="f6f92f00-8bb1-4afa-8ccb-46310b7dd5e5" name="BS" value="4"/>
+        <characteristic characteristicId="da036dbb-32c2-430a-9dd5-aa74e0c4f74b" name="S" value="3"/>
+        <characteristic characteristicId="3f9ed75c-36cd-4169-9cef-48391bb55cfd" name="T" value="3"/>
+        <characteristic characteristicId="17ee558f-3014-4bd2-afc1-b474d8d2b7a8" name="W" value="2"/>
+        <characteristic characteristicId="a558b3ef-04d0-440e-a312-bac3255bf592" name="I" value="7"/>
+        <characteristic characteristicId="5dff3e7c-e024-4030-a71d-03195ec06ea7" name="A" value="4"/>
+        <characteristic characteristicId="4a42059d-12cd-4c1f-a4c7-bb569d13eeea" name="Ld" value="10"/>
+        <characteristic characteristicId="b215fe72-dbce-4ad6-89ec-c4bb3962c39d" name="Save" value="3+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="0329475c-0e20-7f43-ca74-0f284df13d1b" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Two Dreadnought Close Combat Weapons" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="One CCW has Built in Harvester.  Also extra attack included in profile."/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="274da1cc-d0f3-8e8c-4ded-3d27931a934e" profileTypeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" name="Warp-forged Armour" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="21befb24-fc85-4f52-a745-64b2e48f8228" name="Description" value="This grants an armour save of 3+"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+    <profile id="0e74feaf-044b-80dd-3ade-2a2c1d5ae5ec" profileTypeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" name="Warpfire" hidden="false" page="0">
+      <characteristics>
+        <characteristic characteristicId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464" name="Range" value="18&quot;"/>
+        <characteristic characteristicId="a6383362-5aa8-4ff0-b1d0-00e059fc9d45" name="Strength" value="4"/>
+        <characteristic characteristicId="6abee736-f8d3-498e-97ac-a5c68445609f" name="AP" value="4"/>
+        <characteristic characteristicId="077c342f-d7b9-45c6-b8af-88e97cafd3a2" name="Type" value="Assault 3"/>
+      </characteristics>
+      <modifiers/>
+    </profile>
+  </sharedProfiles>
+</catalogue>


### PR DESCRIPTION
Corrected both reports from https://github.com/BSData/wh40k/issues/1907:

Fixed Daemon Prince (Heavy Support) for Hellforged Artefacts.
Updated Nurgle artefacts with profiles & descriptions.